### PR TITLE
fix(release): prepare 0.1.0-alpha.5

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,61 @@
+name: Release Readiness
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  will-release:
+    name: Will Trigger Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run release-plz update preview
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: update
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Decide if merge will release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! git diff --quiet -- Cargo.toml Cargo.lock CHANGELOG.md; then
+            echo "release-plz would update release metadata on merge."
+            git --no-pager diff --name-status -- Cargo.toml Cargo.lock CHANGELOG.md
+            exit 0
+          fi
+
+          crate_name="$(awk -F'"' '/^name = / { print $2; exit }' Cargo.toml)"
+          crate_version="$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)"
+
+          if [[ -z "$crate_name" || -z "$crate_version" ]]; then
+            echo "::error title=Release check failed::Unable to parse crate name/version from Cargo.toml"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/v${crate_version}" >/dev/null; then
+            echo "::error title=No release detected::Tag v${crate_version} already exists, and release-plz has no metadata updates to apply."
+            exit 1
+          fi
+
+          status="$(curl -s -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/${crate_name}/${crate_version}")"
+          if [[ "$status" == "200" ]]; then
+            echo "::error title=No release detected::${crate_name} ${crate_version} is already published on crates.io, and release-plz has no metadata updates to apply."
+            exit 1
+          fi
+          if [[ "$status" != "404" ]]; then
+            echo "::warning title=Crates.io check inconclusive::Received HTTP ${status} from crates.io API."
+          fi
+
+          echo "Current crate version ${crate_version} is not tagged/published, so merge should trigger a release."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0-alpha.5] - 2026-04-21
 
-### 📌 Release Delta Summary
+### 📌 Release Highlights
 
 - Merged major refactor and CI hardening work from recent mainline changes.
 - Added strict rustdoc coverage checks for public library APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 
 - No changes yet.
 
+## [0.1.0-alpha.5] - 2026-04-21
+
+### 📌 Release Delta Summary
+
+- Merged major refactor and CI hardening work from recent mainline changes.
+- Added strict rustdoc coverage checks for public library APIs.
+- Added and validated an mdBook manual with dedicated chapters for:
+  installation, command reference, quality controls, OCR/GPU setup, Plex
+  refresh, Sonarr/Radarr integration, troubleshooting, and build/test flows.
+- Added GitHub Pages deployment workflow for publishing the mdBook on pushes to
+  `main`, and retained PR-time docs validation (`markdownlint`, link checks,
+  mdBook build).
+- Improved release-note generation to capture all commit styles (including
+  unconventional subjects) since the previous tag.
+- Refreshed README to be a concise landing page with Direct Play definition
+  links and handoff to the full manual.
+
 ## [0.1.0-alpha.4] - 2026-04-07
 
 ### 📌 Release Delta Summary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2021"
 
 


### PR DESCRIPTION
## Summary
- bump package version to `0.1.0-alpha.5`
- add explicit changelog section for `0.1.0-alpha.5`

## Why
The previous merged PR landed successfully but did not result in a new published release. This PR forces a concrete release metadata change so `release-plz` can publish the next tag/release.

## Validation
- `cargo check -q`
