### PR TITLE
ci: use App token for release benchmark check + bump alpha.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,11 +251,23 @@ jobs:
     outputs:
       run-benchmarks: ${{ steps.check.outputs.run-benchmarks }}
     env:
-      GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
       BENCHMARK_SOURCE_PATH: ${{ secrets.BENCHMARK_SOURCE_PATH }}
+      FALLBACK_GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
+      - name: Generate runner app token
+        id: runner-app-token
+        if: ${{ secrets.RUNNER_APP_ID != '' && secrets.RUNNER_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RUNNER_APP_ID }}
+          private-key: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - id: check
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.runner-app-token.outputs.token != '' && steps.runner-app-token.outputs.token || env.FALLBACK_GH_TOKEN }}
         run: |
           set -euo pipefail
           if [[ -z "${BENCHMARK_SOURCE_PATH:-}" ]]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 edition = "2021"
 
 


### PR DESCRIPTION
## Summary
- mint a GitHub App installation token in `release.yml` benchmark runner check
- use that token (fallback to existing token) for `gh api` runner inventory query
- bump crate version to `0.1.0-alpha.8` so merging this PR can trigger a fresh prerelease path

## Why
The release benchmark gate was failing/skipping due to `Resource not accessible by integration` when listing self-hosted runners. This switches that API call to your installed app credentials.
