### PR TITLE
ci: fix release workflow parse + bump alpha.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,7 +256,6 @@ jobs:
     steps:
       - name: Generate runner app token
         id: runner-app-token
-        if: ${{ secrets.RUNNER_APP_ID != '' && secrets.RUNNER_APP_PRIVATE_KEY != '' }}
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.RUNNER_APP_ID }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition = "2021"
 
 


### PR DESCRIPTION
## Summary
- remove invalid `if` expression that referenced `secrets.*` at step level in `release.yml`
- keep GitHub App token generation and usage for runner inventory checks
- bump crate version to `0.1.0-alpha.9` to trigger the next prerelease flow

## Why
`Release` runs were failing before any jobs started due to workflow validation (`secrets` context is not allowed in that `if` location). This fix restores release workflow execution so benchmark gating can run.
