### PR TITLE
ci: fix benchmark runner HOME env + bump alpha.10

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -40,6 +40,9 @@ jobs:
       INPUT_SOURCE_PATH: ${{ github.event.inputs.source_path }}
       INPUT_SAMPLE_MS: ${{ github.event.inputs.sample_ms }}
       INPUT_VIDEO_QUALITY: ${{ github.event.inputs.video_quality }}
+      HOME: ${{ github.workspace }}/.gha-home
+      CARGO_HOME: ${{ github.workspace }}/.gha-home/.cargo
+      RUSTUP_HOME: ${{ github.workspace }}/.gha-home/.rustup
     steps:
       - uses: actions/checkout@v4
         with:
@@ -73,6 +76,12 @@ jobs:
             exit 1
           fi
           ffmpeg -hide_banner -encoders | grep -q 'h264_nvenc'
+
+      - name: Prepare Rust home directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,9 @@ jobs:
       run-benchmarks: ${{ steps.check.outputs.run-benchmarks }}
     env:
       BENCHMARK_SOURCE_PATH: ${{ secrets.BENCHMARK_SOURCE_PATH }}
+      HOME: ${{ github.workspace }}/.gha-home
+      CARGO_HOME: ${{ github.workspace }}/.gha-home/.cargo
+      RUSTUP_HOME: ${{ github.workspace }}/.gha-home/.rustup
       FALLBACK_GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Generate runner app token
@@ -325,6 +328,12 @@ jobs:
 
           echo "::error title=Missing benchmark dependencies::Runner image is missing ${missing[*]}. Preinstall them in the self-hosted runner image."
           exit 1
+
+      - name: Prepare Rust home directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 edition = "2021"
 
 


### PR DESCRIPTION
- set writable HOME/CARGO_HOME/RUSTUP_HOME for self-hosted benchmark jobs\n- create those directories before rust-toolchain install\n- bump version to 0.1.0-alpha.10 to trigger a fresh release benchmark run