### PR TITLE
ci: benchmark rust home in /tmp + bump alpha.11

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -40,9 +40,9 @@ jobs:
       INPUT_SOURCE_PATH: ${{ github.event.inputs.source_path }}
       INPUT_SAMPLE_MS: ${{ github.event.inputs.sample_ms }}
       INPUT_VIDEO_QUALITY: ${{ github.event.inputs.video_quality }}
-      HOME: ${{ github.workspace }}/.gha-home
-      CARGO_HOME: ${{ github.workspace }}/.gha-home/.cargo
-      RUSTUP_HOME: ${{ github.workspace }}/.gha-home/.rustup
+      HOME: /tmp/direct-play-nice-gha-home
+      CARGO_HOME: /tmp/direct-play-nice-gha-home/.cargo
+      RUSTUP_HOME: /tmp/direct-play-nice-gha-home/.rustup
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,9 +252,9 @@ jobs:
       run-benchmarks: ${{ steps.check.outputs.run-benchmarks }}
     env:
       BENCHMARK_SOURCE_PATH: ${{ secrets.BENCHMARK_SOURCE_PATH }}
-      HOME: ${{ github.workspace }}/.gha-home
-      CARGO_HOME: ${{ github.workspace }}/.gha-home/.cargo
-      RUSTUP_HOME: ${{ github.workspace }}/.gha-home/.rustup
+      HOME: /tmp/direct-play-nice-gha-home
+      CARGO_HOME: /tmp/direct-play-nice-gha-home/.cargo
+      RUSTUP_HOME: /tmp/direct-play-nice-gha-home/.rustup
       FALLBACK_GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Generate runner app token

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 edition = "2021"
 
 


### PR DESCRIPTION
- move benchmark HOME/CARGO_HOME/RUSTUP_HOME to /tmp to avoid workspace permission issues on plex runner\n- bump version to 0.1.0-alpha.11 to retest release benchmark