### PR TITLE
ci: rename benchmark workflow labels to post-merge

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -1,4 +1,4 @@
-name: Benchmarks
+name: Benchmarks (Post-Merge)
 
 on:
   push:
@@ -251,7 +251,7 @@ jobs:
         run: rm -rf benchmark_artifacts
 
   benchmarks:
-    name: Run Benchmarks
+    name: Run Post-Merge Benchmarks
     runs-on:
       - self-hosted
       - Linux


### PR DESCRIPTION
Renames benchmark workflow/job labels to reflect that it only runs on push to main (post-merge).