### PR TITLE
chore(release): prepare 0.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - No changes yet.
 
-## [0.1.0-alpha.12] - 2026-04-26
+## [0.1.0-beta.1] - 2026-04-26
 
 ### 📌 Release Highlights
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0-beta.1] - 2026-04-26
 
-### 📌 Release Highlights
+### 📌 Beta 1 Highlights
 
 - Landed a large OCR/transcoding refactor focused on clearer module boundaries,
   better reuse, and lower maintenance overhead across the core pipeline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ All notable changes to this project will be documented in this file.
 
 - No changes yet.
 
+## [0.1.0-alpha.12] - 2026-04-26
+
+### 📌 Release Highlights
+
+- Landed a large OCR/transcoding refactor focused on clearer module boundaries,
+  better reuse, and lower maintenance overhead across the core pipeline.
+- Removed vendored third-party OCR source trees from the repository and moved to
+  upstream crate and runtime consumption, reducing repo size and vendoring risk.
+- Added stronger benchmark and fixture-evaluation coverage for OCR quality,
+  fallback behavior, and GPU execution health.
+- Hardened benchmark runner orchestration so post-merge release validation is
+  more deterministic on the self-hosted Plex benchmark runner.
+
+### 🧠 OCR & Language Pipeline
+
+- Added fixture-driven OCR evaluation (`--probe-ocr-fixtures`) with truth-backed
+  CER/WER/similarity reporting for `hybrid`, `strict-gain`, and `pure-onnx`
+  modes.
+- Expanded OCR benchmark diagnostics with explicit fallback counts/rates and
+  averaged confidence/score signals to make quality regressions visible.
+- Improved fallback policy transparency by logging effective non-English
+  Tesseract fallback settings and warning when forced fallback policy is enabled.
+
+### 🧱 Architecture & Code Quality
+
+- Split and clarified core OCR/transcoder responsibilities across dedicated
+  modules (engine setup/core/pipeline/muxing/render and related entrypoints).
+- Reworked broad import patterns and low-signal inline documentation toward
+  clearer contracts and easier refactors.
+- Performed style and cleanup passes to reduce duplication, improve naming and
+  readability, and tighten idiomatic Rust usage under strict `clippy`.
+
+### ⚙️ CI, Benchmarks, and Release Flow
+
+- Added benchmark-runner smoke validation workflow to verify dependency/toolchain
+  readiness and benchmark source availability before release-critical merges.
+- Kept strict verification gates (`fmt`, strict `clippy`, docs with warnings as
+  errors, targeted CLI/OCR tests, concurrency scripts) aligned with refactors.
+- Confirmed post-merge benchmark execution on the self-hosted runner with
+  hardware-accelerated transcode and multi-GPU OCR telemetry artifacts.
+
 ## [0.1.0-alpha.5] - 2026-04-21
 
 ### 📌 Release Highlights

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-alpha.12"
+version = "0.1.0-beta.1"
 edition = "2021"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 edition = "2021"
 
 


### PR DESCRIPTION
## Summary
- bump package version from `0.1.0-alpha.11` to `0.1.0-beta.1`
- add a curated `0.1.0-beta.1` changelog entry for all merged work since `v0.1.0-alpha.11`
- keep `Unreleased` open for future changes

## Included Merge Commits (since `v0.1.0-alpha.11`)
- `febfd2c` ci: add benchmark runner smoke workflow (#85)
- `1f96a35` OCR: harden fallback benchmark diagnostics (#88)
- `bcebe48` refactor: style cleanup (#89)
- `a8b8474` Refactor modules and remove vendored OCR deps (#90)

## Why beta now
`beta` better matches current project maturity: substantial refactors and benchmark hardening have landed, while pre-1.0 iteration remains expected.

## Validation
- local: `cargo check -q`
- CI expected green on this PR:
  - `CI`
  - `Docs`
  - `Security`
  - `Release`
  - `Release Readiness`
  - `Benchmark Runner Smoke`
