### PR TITLE
fix: correct stream routing and Windows remux replacement

### DIFF
--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -371,8 +371,10 @@ pub(crate) enum StreamExtras {
 
 /// Per-stream state carried across decode/encode/mux iterations.
 ///
-/// `skip_stream` lets setup code keep stream ordering aligned with FFmpeg stream
-/// indexes while disabling actual processing for selected streams.
+/// `input_stream_index` and `output_stream_index` are tracked separately because
+/// ignored input streams can shift output stream numbering. `skip_stream` lets
+/// setup code keep stream ordering aligned with FFmpeg stream indexes while
+/// disabling actual processing for selected streams.
 pub(crate) struct StreamProcessingContext {
     pub(crate) input_stream_index: i32,
     pub(crate) output_stream_index: i32,

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -374,9 +374,10 @@ pub(crate) enum StreamExtras {
 /// `skip_stream` lets setup code keep stream ordering aligned with FFmpeg stream
 /// indexes while disabling actual processing for selected streams.
 pub(crate) struct StreamProcessingContext {
+    pub(crate) input_stream_index: i32,
+    pub(crate) output_stream_index: i32,
     pub(crate) decode_context: AVCodecContext,
     pub(crate) encode_context: AVCodecContext,
-    pub(crate) stream_index: i32,
     pub(crate) media_type: ffi::AVMediaType,
     pub(crate) frame_buffer: Option<AVAudioFifo>, // TODO: Support video stream buffers too?
     pub(crate) resample_context: Option<SwrContext>,
@@ -391,7 +392,8 @@ pub(crate) struct StreamProcessingContext {
 impl std::fmt::Debug for StreamProcessingContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("StreamProcessingContext")
-            .field("stream_index", &self.stream_index)
+            .field("input_stream_index", &self.input_stream_index)
+            .field("output_stream_index", &self.output_stream_index)
             .field("media_type", &self.media_type)
             .field("pts", &self.pts)
             .field("last_written_dts", &self.last_written_dts)

--- a/src/subtitle_ocr/muxing.rs
+++ b/src/subtitle_ocr/muxing.rs
@@ -54,6 +54,24 @@ impl SubtitleMuxer {
     }
 }
 
+fn replace_output_file(tmp_out: &Path, output_path: &Path, context: &str) -> Result<()> {
+    #[cfg(windows)]
+    if output_path.exists() {
+        fs::remove_file(output_path).with_context(|| {
+            format!(
+                "removing existing '{}' before {}",
+                output_path.display(),
+                context
+            )
+        })?;
+    }
+
+    fs::rename(tmp_out, output_path)
+        .with_context(|| format!("replacing '{}' after {}", output_path.display(), context))?;
+
+    Ok(())
+}
+
 pub fn remux_copy_streams(input_file: &CStr, output_file: &CStr) -> Result<()> {
     let output_path = PathBuf::from(output_file.to_string_lossy().into_owned());
     let output_extension = output_path
@@ -117,12 +135,7 @@ pub fn remux_copy_streams(input_file: &CStr, output_file: &CStr) -> Result<()> {
 
     output_ctx.write_trailer()?;
 
-    fs::rename(&tmp_out, &output_path).with_context(|| {
-        format!(
-            "replacing '{}' after container remux",
-            output_path.display()
-        )
-    })?;
+    replace_output_file(&tmp_out, &output_path, "container remux")?;
 
     Ok(())
 }
@@ -242,8 +255,7 @@ pub fn mux_text_tracks_from(
 
     output_ctx.write_trailer()?;
 
-    fs::rename(&tmp_out, &output_path)
-        .with_context(|| format!("replacing '{}' after subtitle remux", output_path.display()))?;
+    replace_output_file(&tmp_out, &output_path, "subtitle remux")?;
 
     Ok(())
 }
@@ -457,4 +469,28 @@ pub(super) fn packet_ts(packet: &AVPacket, time_base: ffi::AVRational) -> i64 {
         return 0;
     };
     unsafe { ffi::av_rescale_q(ts, time_base, ra(1, ffi::AV_TIME_BASE as i32)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::replace_output_file;
+    use std::fs;
+
+    #[test]
+    fn replace_output_file_overwrites_existing_destination() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let tmp_out = tmp.path().join("out.tmp");
+        let output = tmp.path().join("out.mp4");
+
+        fs::write(&output, b"old").expect("write existing output");
+        fs::write(&tmp_out, b"new").expect("write temp output");
+
+        replace_output_file(&tmp_out, &output, "unit test").expect("replace output");
+
+        assert_eq!(fs::read(&output).expect("read replaced output"), b"new");
+        assert!(
+            !tmp_out.exists(),
+            "temporary output should be moved into place"
+        );
+    }
 }

--- a/src/subtitle_ocr/muxing.rs
+++ b/src/subtitle_ocr/muxing.rs
@@ -54,6 +54,9 @@ impl SubtitleMuxer {
     }
 }
 
+// Remuxing writes to a temp path first so partial outputs never clobber the
+// destination. Windows cannot rename over an existing file, so remove it
+// explicitly there before moving the temp file into place.
 fn replace_output_file(tmp_out: &Path, output_path: &Path, context: &str) -> Result<()> {
     #[cfg(windows)]
     if output_path.exists() {

--- a/src/transcoder/app_convert.rs
+++ b/src/transcoder/app_convert.rs
@@ -675,9 +675,10 @@ pub(crate) fn convert_video_file(
         output_stream.set_codecpar(encode_context.extract_codecpar());
 
         let stream_process_context = StreamProcessingContext {
+            input_stream_index: stream.index,
+            output_stream_index: output_stream.index,
             decode_context,
             encode_context,
-            stream_index: output_stream.index,
             media_type,
             frame_buffer,
             resample_context,
@@ -712,7 +713,7 @@ pub(crate) fn convert_video_file(
 
         let Some(stream_processing_context) = stream_contexts
             .iter_mut()
-            .find(|context| context.stream_index == packet.stream_index)
+            .find(|context| context.input_stream_index == packet.stream_index)
         else {
             debug!(
                 "Skipping packet for stream {} with no processing context (likely attachment).",
@@ -766,7 +767,7 @@ pub(crate) fn convert_video_file(
                 encode_and_write_frame(
                     &mut context.encode_context,
                     &mut output_format_context,
-                    context.stream_index as usize,
+                    context.output_stream_index as usize,
                     None,
                 )
                 .context("Failed to flush video encoder.")?;
@@ -783,7 +784,7 @@ pub(crate) fn convert_video_file(
                             fifo,
                             &mut output_format_context,
                             &mut context.encode_context,
-                            context.stream_index,
+                            context.output_stream_index,
                             &mut context.pts,
                         )
                         .context("Failed to drain buffered audio samples.")?;
@@ -792,7 +793,7 @@ pub(crate) fn convert_video_file(
                 encode_and_write_frame(
                     &mut context.encode_context,
                     &mut output_format_context,
-                    context.stream_index as usize,
+                    context.output_stream_index as usize,
                     None,
                 )
                 .context("Failed to flush audio encoder.")?;
@@ -829,7 +830,7 @@ pub(crate) fn convert_video_file(
                 if target_video_codec == ffi::AV_CODEC_ID_H264 {
                     info!(
                         "Output video stream {} summary: {}x{} {}{}, bitrate {} bps, profile {}, level {}",
-                        context.stream_index,
+                        context.output_stream_index,
                         context.encode_context.width,
                         context.encode_context.height,
                         describe_codec(target_video_codec),
@@ -841,7 +842,7 @@ pub(crate) fn convert_video_file(
                 } else {
                     info!(
                         "Output video stream {} summary: {}x{} {}{}, bitrate {} bps",
-                        context.stream_index,
+                        context.output_stream_index,
                         context.encode_context.width,
                         context.encode_context.height,
                         describe_codec(target_video_codec),
@@ -861,7 +862,7 @@ pub(crate) fn convert_video_file(
                 };
                 info!(
                     "Output audio stream {} summary: {} ch @ {} Hz {}{}, bitrate {} bps",
-                    context.stream_index,
+                    context.output_stream_index,
                     context.encode_context.ch_layout.nb_channels,
                     context.encode_context.sample_rate,
                     describe_codec(target_audio_codec),
@@ -872,7 +873,7 @@ pub(crate) fn convert_video_file(
             ffi::AVMEDIA_TYPE_SUBTITLE => {
                 info!(
                     "Output subtitle stream {} summary: {}",
-                    context.stream_index,
+                    context.output_stream_index,
                     describe_codec(ffi::AV_CODEC_ID_MOV_TEXT)
                 );
             }

--- a/src/transcoder/pipeline_streams.rs
+++ b/src/transcoder/pipeline_streams.rs
@@ -79,7 +79,7 @@ pub(crate) fn process_video_stream(
         Err(e) => {
             error!(
                 "Video decoder send_packet failure on stream {} (decoder='{}', pts={}, dts={}, duration={}, tb={}/{}): {}",
-                stream_processing_context.stream_index,
+                stream_processing_context.input_stream_index,
                 stream_processing_context.decoder_name,
                 packet.pts,
                 packet.dts,
@@ -90,7 +90,7 @@ pub(crate) fn process_video_stream(
             );
             return Err(anyhow!(DecoderError::new(
                 stream_processing_context.decoder_name.clone(),
-                stream_processing_context.stream_index,
+                stream_processing_context.input_stream_index,
                 e.to_string(),
             )));
         }
@@ -105,7 +105,7 @@ pub(crate) fn process_video_stream(
                 if !std::mem::replace(&mut warned_drain, true) {
                     debug!(
                         "Video decoder drained/flushed for stream {}",
-                        stream_processing_context.stream_index
+                        stream_processing_context.input_stream_index
                     );
                 }
                 break;
@@ -113,14 +113,14 @@ pub(crate) fn process_video_stream(
             Err(e) if is_eagain_error(&e) => {
                 debug!(
                     "Video decoder returned EAGAIN for stream {}",
-                    stream_processing_context.stream_index
+                    stream_processing_context.input_stream_index
                 );
                 break;
             }
             Err(e) => {
                 error!(
                     "Video decoder receive_frame failure on stream {} (decoder='{}', last-packet pts={}, dts={}, duration={}, tb={}/{}): {}",
-                    stream_processing_context.stream_index,
+                    stream_processing_context.input_stream_index,
                     stream_processing_context.decoder_name,
                     packet.pts,
                     packet.dts,
@@ -131,7 +131,7 @@ pub(crate) fn process_video_stream(
                 );
                 return Err(anyhow!(DecoderError::new(
                     stream_processing_context.decoder_name.clone(),
-                    stream_processing_context.stream_index,
+                    stream_processing_context.input_stream_index,
                     format!("receive_frame failed: {}", e),
                 )));
             }
@@ -197,7 +197,7 @@ pub(crate) fn process_video_stream(
         encode_and_write_frame(
             &mut stream_processing_context.encode_context,
             output_format_context,
-            packet.stream_index as usize,
+            stream_processing_context.output_stream_index as usize,
             Some(new_frame),
         )?;
     }
@@ -219,7 +219,7 @@ pub(crate) fn process_audio_stream(
     let Some(fifo) = stream_processing_context.frame_buffer.as_mut() else {
         bail!(
             "Missing audio FIFO buffer for stream {}",
-            stream_processing_context.stream_index
+            stream_processing_context.input_stream_index
         );
     };
 
@@ -232,7 +232,7 @@ pub(crate) fn process_audio_stream(
         Err(e) => {
             error!(
                 "Audio decoder send_packet failure on stream {} (decoder='{}', pts={}, dts={}, duration={}, tb={}/{}): {}",
-                stream_processing_context.stream_index,
+                stream_processing_context.input_stream_index,
                 stream_processing_context.decoder_name,
                 packet.pts,
                 packet.dts,
@@ -243,7 +243,7 @@ pub(crate) fn process_audio_stream(
             );
             return Err(anyhow!(DecoderError::new(
                 stream_processing_context.decoder_name.clone(),
-                stream_processing_context.stream_index,
+                stream_processing_context.input_stream_index,
                 e.to_string(),
             )));
         }
@@ -258,7 +258,7 @@ pub(crate) fn process_audio_stream(
                 if !std::mem::replace(&mut warned_drain, true) {
                     debug!(
                         "Audio decoder drained/flushed for stream {}",
-                        stream_processing_context.stream_index
+                        stream_processing_context.input_stream_index
                     );
                 }
                 break;
@@ -266,14 +266,14 @@ pub(crate) fn process_audio_stream(
             Err(e) if is_eagain_error(&e) => {
                 debug!(
                     "Audio decoder returned EAGAIN for stream {}",
-                    stream_processing_context.stream_index
+                    stream_processing_context.input_stream_index
                 );
                 break;
             }
             Err(e) => {
                 error!(
                     "Audio decoder receive_frame failure on stream {} (decoder='{}', last-packet pts={}, dts={}, duration={}, tb={}/{}): {}",
-                    stream_processing_context.stream_index,
+                    stream_processing_context.input_stream_index,
                     stream_processing_context.decoder_name,
                     packet.pts,
                     packet.dts,
@@ -284,7 +284,7 @@ pub(crate) fn process_audio_stream(
                 );
                 return Err(anyhow!(DecoderError::new(
                     stream_processing_context.decoder_name.clone(),
-                    stream_processing_context.stream_index,
+                    stream_processing_context.input_stream_index,
                     format!("receive_frame failed: {}", e),
                 )));
             }
@@ -324,14 +324,14 @@ pub(crate) fn process_audio_stream(
         debug!("FIFO SIZE: {}", fifo.size());
         debug!(
             "AUDIO STREAM INDEX: {}",
-            stream_processing_context.stream_index
+            stream_processing_context.output_stream_index
         );
         while fifo.size() >= output_frame_size {
             load_encode_and_write(
                 fifo,
                 output_format_context,
                 &mut stream_processing_context.encode_context,
-                stream_processing_context.stream_index,
+                stream_processing_context.output_stream_index,
                 &mut stream_processing_context.pts,
             )?;
         }
@@ -349,7 +349,7 @@ pub(crate) fn process_subtitle_stream(
     if stream_processing_context.skip_stream {
         trace!(
             "Subtitle stream {} already skipped; dropping packet.",
-            stream_processing_context.stream_index
+            stream_processing_context.input_stream_index
         );
         return Ok(());
     }
@@ -367,7 +367,10 @@ pub(crate) fn process_subtitle_stream(
             if let Some(subtitle) = sub {
                 debug!(
                     "Subtitle stream {} raw packet pts={} dts={} duration={}",
-                    stream_processing_context.stream_index, packet.pts, packet.dts, packet.duration
+                    stream_processing_context.input_stream_index,
+                    packet.pts,
+                    packet.dts,
+                    packet.duration
                 );
                 // Conservative fixed buffer to avoid per-packet allocations in the hot path.
                 // If we see larger subtitle payloads in the future, raise this value or switch
@@ -421,14 +424,14 @@ pub(crate) fn process_subtitle_stream(
                     dts = pts;
                 }
 
-                encoded_packet.set_stream_index(stream_processing_context.stream_index);
+                encoded_packet.set_stream_index(stream_processing_context.output_stream_index);
                 encoded_packet.set_pts(pts);
                 encoded_packet.set_dts(dts);
                 encoded_packet.set_duration(packet.duration);
                 encoded_packet.set_flags(packet.flags);
 
                 let output_time_base = output_format_context.streams()
-                    [stream_processing_context.stream_index as usize]
+                    [stream_processing_context.output_stream_index as usize]
                     .time_base;
                 encoded_packet.rescale_ts(
                     stream_processing_context.decode_context.time_base,
@@ -445,7 +448,7 @@ pub(crate) fn process_subtitle_stream(
                         }
                         debug!(
                             "Subtitle stream {} adjusted DTS from {} to {}",
-                            stream_processing_context.stream_index, packet_dts, adjusted
+                            stream_processing_context.input_stream_index, packet_dts, adjusted
                         );
                     }
                 }
@@ -453,7 +456,7 @@ pub(crate) fn process_subtitle_stream(
                 stream_processing_context.last_written_dts = Some(encoded_packet.dts);
                 debug!(
                     "Subtitle stream {} final pts={} dts={} duration={} (tb={}/{})",
-                    stream_processing_context.stream_index,
+                    stream_processing_context.input_stream_index,
                     encoded_packet.pts,
                     encoded_packet.dts,
                     encoded_packet.duration,
@@ -466,7 +469,7 @@ pub(crate) fn process_subtitle_stream(
                     Err(rsmpeg::error::RsmpegError::AVError(code)) if code == -EINVAL => {
                         warn!(
                             "Subtitle stream {} produced invalid timestamps; skipping rest of stream.",
-                            stream_processing_context.stream_index
+                            stream_processing_context.input_stream_index
                         );
                         stream_processing_context.skip_stream = true;
                     }

--- a/tests/cli_multi_video_skip.rs
+++ b/tests/cli_multi_video_skip.rs
@@ -1,0 +1,67 @@
+#![cfg(feature = "ffmpeg-cli-tests")]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use rsmpeg::avformat::AVFormatContextInput;
+use rsmpeg::ffi;
+use std::ffi::CString;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn cli_ignores_secondary_video_stream_without_misrouting_audio_packets(
+) -> Result<(), Box<dyn std::error::Error>> {
+    common::ensure_ffmpeg_present();
+
+    let tmp = TempDir::new()?;
+    let (input, in_dur_ms) = common::gen_multi_video_input(&tmp);
+    let output = tmp.path().join("out.mp4");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("direct_play_nice"));
+    cmd.arg("-s")
+        .arg("chromecast_1st_gen,chromecast_2nd_gen,chromecast_ultra")
+        .arg("--hw-accel")
+        .arg("none")
+        .arg("--sub-mode")
+        .arg("skip")
+        .arg("--unsupported-video-policy")
+        .arg("ignore")
+        .arg(&input)
+        .arg(&output);
+    common::assert_cli_success(cmd);
+
+    let output_cstr = CString::new(output.to_string_lossy().to_string()).unwrap();
+    let octx = AVFormatContextInput::open(output_cstr.as_c_str())?;
+
+    let mut video_streams = 0usize;
+    let mut audio_streams = 0usize;
+    for st in octx.streams() {
+        let par = st.codecpar();
+        match par.codec_type {
+            t if t == ffi::AVMEDIA_TYPE_VIDEO => {
+                video_streams += 1;
+                assert_eq!(par.codec_id, ffi::AV_CODEC_ID_H264);
+            }
+            t if t == ffi::AVMEDIA_TYPE_AUDIO => {
+                audio_streams += 1;
+                assert_eq!(par.codec_id, ffi::AV_CODEC_ID_AAC);
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(video_streams, 1, "expected exactly one output video stream");
+    assert_eq!(audio_streams, 1, "expected exactly one output audio stream");
+
+    let out_dur_ms = common::probe_duration_ms(&output);
+    let diff = out_dur_ms.abs_diff(in_dur_ms);
+    assert!(
+        diff <= 250,
+        "duration drift too large: in={}ms out={}ms",
+        in_dur_ms,
+        out_dur_ms
+    );
+
+    Ok(())
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -135,6 +135,47 @@ pub fn gen_odd_width_input(tmp: &TempDir) -> (PathBuf, u64) {
     (input, dur_ms)
 }
 
+pub fn gen_multi_video_input(tmp: &TempDir) -> (PathBuf, u64) {
+    let dir = tmp.path();
+    let input = dir.join("multi_video.mkv");
+
+    let status_mux = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=640x360:rate=25:duration=2",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=320x240:rate=25:duration=2",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:sample_rate=44100:duration=2",
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:v:0",
+            "-map",
+            "2:a:0",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:v",
+            "mpeg4",
+            "-c:a",
+            "mp2",
+            input.to_str().expect("path utf8"),
+        ])
+        .status()
+        .expect("run ffmpeg multi-video mux");
+    assert!(status_mux.success(), "ffmpeg multi-video mux failed");
+
+    let dur_ms = probe_duration_ms(&input);
+    (input, dur_ms)
+}
+
 pub fn probe_duration_ms(path: &Path) -> u64 {
     let input_cstr = CString::new(path.to_string_lossy().to_string()).unwrap();
     let ictx = AVFormatContextInput::open(input_cstr.as_c_str()).unwrap();


### PR DESCRIPTION
## Summary
- separate input and output stream indices so extra ignored video streams cannot misroute later packets
- use a Windows-safe output replacement helper for container and subtitle remux paths
- add a multi-video CLI regression test for `--unsupported-video-policy ignore`
- clarify the new stream-routing and remux helper behavior with purpose-level comments

## Windows bug
- Resolves the Windows remux overwrite failure tracked in #95

## Validation
- cargo test -q
- cargo clippy -q --all-targets --all-features -- -D warnings
- cargo test -q --features ffmpeg-cli-tests cli_ignores_secondary_video_stream_without_misrouting_audio_packets
- remote Silence transcode benchmark on plexserver (`run_transcode_benchmark.sh`, 300s trim, nvenc)
- remote Silence OCR benchmark on plexserver (`run_ocr_stress_benchmark.sh`, 300s trim, pp-ocr-v3, gpu required)
