### PR TITLE
ci: scope Windows PR runtime to vcpkg changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Compute vcpkg fingerprint
+        id: vcpkg-fingerprint
+        run: |
+          echo "cache_key=$(python3 scripts/ci/vcpkg_fingerprint.py --repo-root . --cargo-toml Cargo.toml)" >> "$GITHUB_OUTPUT"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -99,9 +103,9 @@ jobs:
             target/vcpkg/scripts
             target/vcpkg/triplets
             target/vcpkg/vcpkg
-          key: vcpkg-root-linux-v2-${{ hashFiles('Cargo.toml') }}
+          key: vcpkg-root-linux-v3-${{ steps.vcpkg-fingerprint.outputs.cache_key }}
           restore-keys: |
-            vcpkg-root-linux-v2-
+            vcpkg-root-linux-v3-
 
       - name: Validate vcpkg cache origin
         run: |
@@ -293,6 +297,49 @@ jobs:
       VCPKGRS_TRIPLET: x64-windows-static-md
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Keep PR coverage on Windows, but only pay for the full FFmpeg runtime
+      # suite when native inputs changed or a PR opts in explicitly.
+      - name: Compute Windows vcpkg fingerprint and CI scope
+        id: vcpkg-scope-win
+        shell: pwsh
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          $fingerprint = py -3 scripts/ci/vcpkg_fingerprint.py --repo-root . --cargo-toml Cargo.toml --target x86_64-pc-windows-msvc
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "cache_key=$fingerprint"
+
+          $runtimeRequired = $false
+          $runtimeReason = "compile-only"
+          $runtimeMode = "compile-only"
+          $prText = "$env:PR_TITLE`n$env:PR_BODY"
+
+          if ($prText -match '\[windows-full-ci\]') {
+            $runtimeRequired = $true
+            $runtimeReason = "manual override token"
+          }
+
+          if (-not $runtimeRequired -and $env:PR_BASE_SHA) {
+            $baseFingerprint = py -3 scripts/ci/vcpkg_fingerprint.py --repo-root . --cargo-toml Cargo.toml --target x86_64-pc-windows-msvc --git-treeish $env:PR_BASE_SHA
+            if ($LASTEXITCODE -ne 0) {
+              $runtimeRequired = $true
+              $runtimeReason = "base fingerprint unavailable"
+            } elseif ($fingerprint -ne $baseFingerprint) {
+              $runtimeRequired = $true
+              $runtimeReason = "vcpkg fingerprint changed"
+            }
+          }
+
+          if ($runtimeRequired) {
+            $runtimeMode = "runtime"
+          }
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "runtime_required=$($runtimeRequired.ToString().ToLower())"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "runtime_reason=$runtimeReason"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "runtime_mode=$runtimeMode"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -354,9 +401,9 @@ jobs:
             target/vcpkg/triplets
             target/vcpkg/vcpkg
             target/vcpkg/vcpkg.exe
-          key: vcpkg-root-windows-v3-${{ hashFiles('Cargo.toml') }}
+          key: vcpkg-root-windows-v4-${{ steps.vcpkg-scope-win.outputs.cache_key }}
           restore-keys: |
-            vcpkg-root-windows-v3-
+            vcpkg-root-windows-v4-
 
       - name: Validate vcpkg cache origin
         shell: pwsh
@@ -461,7 +508,7 @@ jobs:
             target/vcpkg/triplets
             target/vcpkg/vcpkg
             target/vcpkg/vcpkg.exe
-          key: vcpkg-root-windows-v3-${{ hashFiles('Cargo.toml') }}
+          key: vcpkg-root-windows-v4-${{ steps.vcpkg-scope-win.outputs.cache_key }}
 
       - name: Force regenerate rusty_ffmpeg bindings
         run: cargo clean -p rusty_ffmpeg
@@ -476,7 +523,7 @@ jobs:
             target/vcpkg/buildtrees/**/*.txt
           retention-days: 7
 
-      - name: Run tests
+      - name: Run Windows unit/bin test suite
         shell: pwsh
         env:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
@@ -495,17 +542,45 @@ jobs:
           DPN_OCR_AI_E2E: "1"
           DPN_OCR_MODEL_DIR: ${{ github.workspace }}\\target\\ocr-models
         run: |
-          $start = Get-Date
           $threads = [Math]::Max(1, [int]$env:NUMBER_OF_PROCESSORS)
           cargo test -q --lib --bins --tests -- --test-threads $threads
-          cargo test --features ffmpeg-cli-tests -- --test-threads $threads
-          $elapsed = (Get-Date) - $start
+
+      - name: Compile Windows FFmpeg CLI suite
+        shell: pwsh
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+          VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
+          DPN_OCR_GOLDEN: "1"
+          DPN_OCR_AI_E2E: "1"
+          DPN_OCR_MODEL_DIR: ${{ github.workspace }}\\target\\ocr-models
+        run: cargo test -q --features ffmpeg-cli-tests --no-run
+
+      - name: Run Windows FFmpeg CLI runtime suite
+        if: steps.vcpkg-scope-win.outputs.runtime_required == 'true'
+        shell: pwsh
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+          VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
+          DPN_OCR_GOLDEN: "1"
+          DPN_OCR_AI_E2E: "1"
+          DPN_OCR_MODEL_DIR: ${{ github.workspace }}\\target\\ocr-models
+        run: |
+          $threads = [Math]::Max(1, [int]$env:NUMBER_OF_PROCESSORS)
+          cargo test -q --features ffmpeg-cli-tests -- --test-threads $threads
+
+      - name: Summarize Windows CI
+        if: always()
+        shell: pwsh
+        run: |
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Windows runtime"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Toolchain: stable"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- vcpkg cache hit: ${{ steps.vcpkg-root-cache-win.outputs.cache-hit }}"
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Test command: cargo test --lib --bins --tests"
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Includes ffmpeg-cli-tests runtime execution: yes"
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ("- Duration: {0}s" -f [int]$elapsed.TotalSeconds)
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Unit/bin suite: cargo test --lib --bins --tests"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- FFmpeg CLI compile check: cargo test --features ffmpeg-cli-tests --no-run"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- FFmpeg CLI mode: ${{ steps.vcpkg-scope-win.outputs.runtime_mode }} (${{ steps.vcpkg-scope-win.outputs.runtime_reason }})"
+          if ("${{ steps.vcpkg-scope-win.outputs.runtime_mode }}" -eq "runtime") {
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- FFmpeg CLI runtime suite: cargo test --features ffmpeg-cli-tests"
+          }
 
       - name: sccache stats
         if: ${{ env.RUSTC_WRAPPER == 'sccache' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           $fingerprint = py -3 scripts/ci/vcpkg_fingerprint.py --repo-root . --cargo-toml Cargo.toml --target x86_64-pc-windows-msvc
           Add-Content -Path $env:GITHUB_OUTPUT -Value "cache_key=$fingerprint"
@@ -316,6 +317,10 @@ jobs:
           $runtimeReason = "compile-only"
           $runtimeMode = "compile-only"
           $prText = "$env:PR_TITLE`n$env:PR_BODY"
+          $runtimeTriggerFiles = @(
+            ".github/workflows/ci.yml",
+            "scripts/ci/vcpkg_fingerprint.py"
+          )
 
           if ($prText -match '\[windows-full-ci\]') {
             $runtimeRequired = $true
@@ -330,6 +335,25 @@ jobs:
             } elseif ($fingerprint -ne $baseFingerprint) {
               $runtimeRequired = $true
               $runtimeReason = "vcpkg fingerprint changed"
+            }
+          }
+
+          if (-not $runtimeRequired -and $env:PR_BASE_SHA -and $env:PR_HEAD_SHA) {
+            $changedFiles = git diff --name-only "$env:PR_BASE_SHA...$env:PR_HEAD_SHA"
+            if ($LASTEXITCODE -ne 0) {
+              $runtimeRequired = $true
+              $runtimeReason = "changed-file scope unavailable"
+            } elseif ($changedFiles) {
+              # These files directly control native dependency caching/scope.
+              # When they change, validate the full Windows runtime path instead
+              # of trusting compile-only coverage.
+              foreach ($changedFile in $changedFiles) {
+                if ($runtimeTriggerFiles -contains $changedFile.Trim()) {
+                  $runtimeRequired = $true
+                  $runtimeReason = "windows vcpkg ci logic changed"
+                  break
+                }
+              }
             }
           }
 

--- a/scripts/ci/vcpkg_fingerprint.py
+++ b/scripts/ci/vcpkg_fingerprint.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Build a stable fingerprint for the repository's vcpkg inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+
+COMPANION_FILES = (
+    "vcpkg.json",
+    "vcpkg-configuration.json",
+    "VCPKG_DEPS_LIST.txt",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Emit a stable hash for the vcpkg inputs used by CI."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root used to resolve Cargo.toml and optional companion files.",
+    )
+    parser.add_argument(
+        "--cargo-toml",
+        default="Cargo.toml",
+        help="Cargo.toml path relative to --repo-root.",
+    )
+    parser.add_argument(
+        "--target",
+        help="Optional target triple whose vcpkg target metadata should be included.",
+    )
+    parser.add_argument(
+        "--git-treeish",
+        help="Optional git tree-ish used to read files from the repository instead of disk.",
+    )
+    parser.add_argument(
+        "--print-payload",
+        action="store_true",
+        help="Print the normalized payload instead of the hash.",
+    )
+    return parser.parse_args()
+
+
+def read_text(repo_root: Path, rel_path: str, treeish: str | None, required: bool) -> str | None:
+    if treeish is None:
+        full_path = repo_root / rel_path
+        if not full_path.exists():
+            if required:
+                raise FileNotFoundError(full_path)
+            return None
+        return full_path.read_text(encoding="utf-8")
+
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{treeish}:{rel_path}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        if required:
+            raise RuntimeError(
+                f"unable to read '{rel_path}' from git tree '{treeish}': {result.stderr.strip()}"
+            )
+        return None
+    return result.stdout
+
+
+def normalize(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: normalize(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        normalized = [normalize(item) for item in value]
+        if all(not isinstance(item, (dict, list)) for item in normalized):
+            return sorted(normalized, key=lambda item: json.dumps(item, sort_keys=True))
+        return normalized
+    return value
+
+
+def build_payload(
+    repo_root: Path,
+    cargo_toml: str,
+    target: str | None,
+    treeish: str | None,
+) -> dict[str, Any]:
+    cargo_doc = tomllib.loads(read_text(repo_root, cargo_toml, treeish, required=True) or "")
+    vcpkg_meta = cargo_doc.get("package", {}).get("metadata", {}).get("vcpkg", {})
+    payload: dict[str, Any] = {
+        "cargo_vcpkg": {
+            "git": vcpkg_meta.get("git"),
+            "rev": vcpkg_meta.get("rev"),
+            "dependencies": vcpkg_meta.get("dependencies", []),
+        }
+    }
+
+    targets = vcpkg_meta.get("target", {})
+    if target:
+        payload["cargo_vcpkg"]["target"] = {target: targets.get(target, {})}
+
+    companion_payload: dict[str, Any] = {}
+    for companion in COMPANION_FILES:
+        text = read_text(repo_root, companion, treeish, required=False)
+        if text is None:
+            continue
+        if companion.endswith(".json"):
+            companion_payload[companion] = json.loads(text)
+        else:
+            companion_payload[companion] = [
+                line.rstrip()
+                for line in text.splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            ]
+
+    if companion_payload:
+        payload["companion_files"] = companion_payload
+
+    return normalize(payload)
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    payload = build_payload(repo_root, args.cargo_toml, args.target, args.git_treeish)
+
+    if args.print_payload:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    print(hashlib.sha256(encoded).hexdigest())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- key the PR vcpkg caches off a vcpkg-specific fingerprint instead of the whole Cargo.toml
- keep Windows PR coverage, but default the expensive FFmpeg CLI suite to compile-only
- automatically run the full Windows FFmpeg CLI runtime suite when the vcpkg fingerprint changes, when the Windows vcpkg CI control path changes, or when the PR opts in with `[windows-full-ci]`

## Validation
- python helper fingerprint unchanged for unrelated Cargo.toml edits
- python helper fingerprint changed for vcpkg metadata edits
- workflow YAML parses successfully
- git diff --check
