### PR TITLE
Publish release binaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,6 +23,62 @@ rustflags = [
   "link-arg=User32.lib",
 ]
 
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=AudioToolbox",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=CoreFoundation",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=CoreMedia",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=CoreVideo",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=Security",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=VideoToolbox",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=AudioToolbox",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=CoreFoundation",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=CoreMedia",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=CoreVideo",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=Security",
+  "-C",
+  "link-arg=-framework",
+  "-C",
+  "link-arg=VideoToolbox",
+]
+
 [env]
 RUST_LOG = "info"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,11 +14,13 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       packages: write
     env:
       EFFECTIVE_GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || github.token }}
+      RELEASE_PLZ_TOKEN_CONFIGURED: ${{ secrets.RELEASE_PLZ_TOKEN != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -172,10 +174,45 @@ jobs:
           git commit -m "chore(release): update versions and changelog [skip ci]"
           git push origin HEAD:main
 
+      - name: Capture release tags before release-plz
+        if: ${{ env.RELEASE_PLZ_TOKEN_CONFIGURED != 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          git tag --list | sort > "$RUNNER_TEMP/release-tags-before.txt"
+
       - name: Run release-plz (release)
+        id: release-plz-release
         uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ env.EFFECTIVE_GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Dispatch binary release workflow
+        if: ${{ env.RELEASE_PLZ_TOKEN_CONFIGURED != 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          before="$RUNNER_TEMP/release-tags-before.txt"
+          after="$RUNNER_TEMP/release-tags-after.txt"
+
+          git fetch --tags --force
+          git tag --list | sort > "$after"
+
+          new_tags="$(comm -13 "$before" "$after" | grep -E '(^|/|v)[0-9]+\.[0-9]+\.[0-9]+' || true)"
+          if [[ -z "$new_tags" ]]; then
+            echo "No new release tags created; skipping binary release dispatch."
+            exit 0
+          fi
+
+          while IFS= read -r release_tag; do
+            [[ -n "$release_tag" ]] || continue
+            echo "Dispatching binary release workflow for ${release_tag}."
+            gh workflow run release.yml --ref "$release_tag" -f tag="$release_tag"
+          done <<< "$new_tags"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,12 +515,22 @@ jobs:
         run: sccache --show-stats; if ($LASTEXITCODE -ne 0) { exit 0 }
 
   macos-test:
-    name: Test (macOS Intel)
+    name: Test (macOS ${{ matrix.name }})
     if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.body, '[skip ci]')) }}
-    runs-on: macos-15-intel
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       actions: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Intel
+            runner: macos-15-intel
+            cache_suffix: macos-intel
+          - name: Apple Silicon
+            runner: macos-15
+            cache_suffix: macos-arm64
     env:
       CARGO_TERM_COLOR: always
       VCPKG_ROOT: ${{ github.workspace }}/target/vcpkg
@@ -554,7 +564,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cargo-vcpkg
-          key: cargo-vcpkg-macos-v1
+          key: cargo-vcpkg-${{ matrix.cache_suffix }}-v1
 
       - name: Install cargo-vcpkg
         if: steps.cargo-vcpkg-cache-macos.outputs.cache-hit != 'true'
@@ -565,7 +575,7 @@ jobs:
       - name: Cache cargo build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: macos-vcpkg-v1-ffmpeg8
+          prefix-key: ${{ matrix.cache_suffix }}-vcpkg-v1-ffmpeg8
 
       - name: Restore vcpkg workspace (cross-branch)
         id: vcpkg-root-cache-macos
@@ -581,9 +591,9 @@ jobs:
             target/vcpkg/scripts
             target/vcpkg/triplets
             target/vcpkg/vcpkg
-          key: vcpkg-root-macos-v1-${{ hashFiles('Cargo.toml') }}
+          key: vcpkg-root-${{ matrix.cache_suffix }}-v1-${{ hashFiles('Cargo.toml') }}
           restore-keys: |
-            vcpkg-root-macos-v1-
+            vcpkg-root-${{ matrix.cache_suffix }}-v1-
 
       - name: Validate vcpkg cache origin
         run: |
@@ -652,7 +662,7 @@ jobs:
             target/vcpkg/scripts
             target/vcpkg/triplets
             target/vcpkg/vcpkg
-          key: vcpkg-root-macos-v1-${{ hashFiles('Cargo.toml') }}
+          key: vcpkg-root-${{ matrix.cache_suffix }}-v1-${{ hashFiles('Cargo.toml') }}
 
       - name: Force regenerate rusty_ffmpeg bindings
         run: cargo clean -p rusty_ffmpeg
@@ -661,7 +671,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: vcpkg-logs-macos
+          name: vcpkg-logs-${{ matrix.cache_suffix }}
           path: |
             target/vcpkg/buildtrees/**/*.log
             target/vcpkg/buildtrees/**/*.txt
@@ -679,7 +689,7 @@ jobs:
           end=$(date +%s)
           echo "### macOS test runtime" >> "$GITHUB_STEP_SUMMARY"
           echo "- Toolchain: stable" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Runner: macos-15-intel" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Runner: ${{ matrix.runner }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- vcpkg cache hit: ${{ steps.vcpkg-root-cache-macos.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Test command: cargo test --lib --bins --tests" >> "$GITHUB_STEP_SUMMARY"
           echo "- Integration compile check: cargo test --features ffmpeg-cli-tests --no-run" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Set up sccache
         id: sccache-setup
         uses: mozilla-actions/sccache-action@v0.0.5
+        continue-on-error: true
 
       - name: Install dependencies
         run: |
@@ -301,6 +302,7 @@ jobs:
       - name: Set up sccache
         id: sccache-setup
         uses: mozilla-actions/sccache-action@v0.0.5
+        continue-on-error: true
 
       - name: Set job-level RUSTC_WRAPPER
         if: steps.sccache-setup.outcome == 'success'
@@ -533,6 +535,7 @@ jobs:
       - name: Set up sccache
         id: sccache-setup
         uses: mozilla-actions/sccache-action@v0.0.5
+        continue-on-error: true
 
       - name: Set job-level RUSTC_WRAPPER
         if: steps.sccache-setup.outcome == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,180 @@ jobs:
         shell: pwsh
         run: sccache --show-stats; if ($LASTEXITCODE -ne 0) { exit 0 }
 
+  macos-test:
+    name: Test (macOS Intel)
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.body, '[skip ci]')) }}
+    runs-on: macos-15-intel
+    permissions:
+      contents: read
+      actions: write
+    env:
+      CARGO_TERM_COLOR: always
+      VCPKG_ROOT: ${{ github.workspace }}/target/vcpkg
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up sccache
+        id: sccache-setup
+        uses: mozilla-actions/sccache-action@v0.0.5
+
+      - name: Set job-level RUSTC_WRAPPER
+        if: steps.sccache-setup.outcome == 'success'
+        run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+      - name: Clear RUSTC_WRAPPER on sccache failure
+        if: steps.sccache-setup.outcome == 'failure'
+        run: echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: |
+          brew install nasm autoconf autoconf-archive automake libtool pkg-config
+
+      - name: Cache cargo-vcpkg binary
+        id: cargo-vcpkg-cache-macos
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-vcpkg
+          key: cargo-vcpkg-macos-v1
+
+      - name: Install cargo-vcpkg
+        if: steps.cargo-vcpkg-cache-macos.outputs.cache-hit != 'true'
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+        run: cargo install cargo-vcpkg --locked
+
+      - name: Cache cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: macos-vcpkg-v1-ffmpeg8
+
+      - name: Restore vcpkg workspace (cross-branch)
+        id: vcpkg-root-cache-macos
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            target/vcpkg/.vcpkg-root
+            target/vcpkg/.git
+            target/vcpkg/downloads
+            target/vcpkg/installed
+            target/vcpkg/packages
+            target/vcpkg/ports
+            target/vcpkg/scripts
+            target/vcpkg/triplets
+            target/vcpkg/vcpkg
+          key: vcpkg-root-macos-v1-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            vcpkg-root-macos-v1-
+
+      - name: Validate vcpkg cache origin
+        run: |
+          cache_invalid=0
+          expected_rev="$(grep -E '^rev = "' Cargo.toml | head -n1 | awk -F'"' '{print $2}')"
+          if [ -e "target/vcpkg" ] && [ ! -e "target/vcpkg/.git" ]; then
+            echo "vcpkg root missing .git; clearing cache entry"
+            rm -rf target/vcpkg
+            cache_invalid=1
+          fi
+          for dir in target/vcpkg target/vcpkg/.vcpkg-root target/vcpkg/vcpkg; do
+            if [ -e "$dir/.git" ]; then
+              origin=$(git -C "$dir" remote get-url origin 2>/dev/null || true)
+              if [ -z "$origin" ]; then
+                echo "Failed to read vcpkg origin in $dir; clearing cache entry"
+                rm -rf "$dir"
+                cache_invalid=1
+                continue
+              fi
+              if [ "$origin" != "https://github.com/microsoft/vcpkg.git" ] && [ "$origin" != "https://github.com/microsoft/vcpkg" ]; then
+                echo "Unexpected vcpkg origin in $dir: $origin"
+                rm -rf "$dir"
+                cache_invalid=1
+                continue
+              fi
+              if [ -n "$expected_rev" ]; then
+                if ! git -C "$dir" cat-file -e "${expected_rev}^{tree}" 2>/dev/null; then
+                  echo "Missing vcpkg rev $expected_rev in $dir; clearing cache entry"
+                  rm -rf "$dir"
+                  cache_invalid=1
+                fi
+              fi
+            fi
+          done
+          if [ "$cache_invalid" -eq 1 ]; then
+            echo "VCPKG_CACHE_INVALID=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Use cached vcpkg workspace
+        if: steps.vcpkg-root-cache-macos.outputs.cache-hit == 'true' && env.VCPKG_CACHE_INVALID != '1'
+        run: echo "vcpkg workspace cache hit; skipping dependency rebuild."
+
+      - name: Build vcpkg dependencies
+        if: steps.vcpkg-root-cache-macos.outputs.cache-hit != 'true' || env.VCPKG_CACHE_INVALID == '1'
+        env:
+          VCPKG_BUILD_TYPE: release
+          VCPKG_FEATURE_FLAGS: manifests,binarycaching
+          VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+          VCPKG_CMAKE_CONFIGURE_OPTIONS: -Wno-dev -DCMAKE_POLICY_DEFAULT_CMP0174=NEW
+          VCPKG_MAX_CONCURRENCY: 2
+          CMAKE_BUILD_PARALLEL_LEVEL: 2
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+        run: cargo vcpkg --verbose build
+
+      - name: Save vcpkg workspace cache
+        if: (steps.vcpkg-root-cache-macos.outputs.cache-hit != 'true' || env.VCPKG_CACHE_INVALID == '1') && success()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            target/vcpkg/.vcpkg-root
+            target/vcpkg/.git
+            target/vcpkg/downloads
+            target/vcpkg/installed
+            target/vcpkg/packages
+            target/vcpkg/ports
+            target/vcpkg/scripts
+            target/vcpkg/triplets
+            target/vcpkg/vcpkg
+          key: vcpkg-root-macos-v1-${{ hashFiles('Cargo.toml') }}
+
+      - name: Force regenerate rusty_ffmpeg bindings
+        run: cargo clean -p rusty_ffmpeg
+
+      - name: Upload vcpkg logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vcpkg-logs-macos
+          path: |
+            target/vcpkg/buildtrees/**/*.log
+            target/vcpkg/buildtrees/**/*.txt
+          retention-days: 7
+
+      - name: Run tests
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+          VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
+          DPN_OCR_GOLDEN: "1"
+        run: |
+          start=$(date +%s)
+          cargo test -q --lib --bins --tests
+          cargo test -q --features ffmpeg-cli-tests --no-run
+          end=$(date +%s)
+          echo "### macOS test runtime" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Toolchain: stable" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Runner: macos-15-intel" >> "$GITHUB_STEP_SUMMARY"
+          echo "- vcpkg cache hit: ${{ steps.vcpkg-root-cache-macos.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Test command: cargo test --lib --bins --tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Integration compile check: cargo test --features ffmpeg-cli-tests --no-run" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Duration: $((end-start))s" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: sccache stats
+        if: ${{ env.RUSTC_WRAPPER == 'sccache' }}
+        run: sccache --show-stats || true
+
   ocr-gpu-self-hosted:
     name: OCR GPU (Self-Hosted)
     if: ${{ vars.ENABLE_GPU_CI == '1' && (github.event_name != 'pull_request' || (!contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.body, '[skip ci]'))) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ env:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and publish, for example v0.1.0"
+        required: true
+        type: string
   pull_request:
   push:
     tags:
@@ -53,15 +59,35 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ steps.release-context.outputs.tag }}
+      tag-flag: ${{ steps.release-context.outputs.tag-flag }}
+      publishing: ${{ steps.release-context.outputs.publishing }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - id: release-context
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            {
+              echo "tag="
+              echo "tag-flag="
+              echo "publishing=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "tag=$RELEASE_TAG"
+            echo "tag-flag=--tag=$RELEASE_TAG"
+            echo "publishing=true"
+          } >> "$GITHUB_OUTPUT"
       - name: Install cargo-dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
@@ -78,8 +104,15 @@ jobs:
       # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ steps.release-context.outputs.tag }}
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --allow-dirty --output-format=json > plan-dist-manifest.json
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            cargo dist plan --allow-dirty --output-format=json > plan-dist-manifest.json
+          else
+            cargo dist host --steps=create --tag="$RELEASE_TAG" --allow-dirty --output-format=json > plan-dist-manifest.json
+          fi
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,20 @@ dependencies = [
   "x264[asm,core]",
 ]
 
+[package.metadata.vcpkg.target.x86_64-apple-darwin]
+triplet = "x64-osx"
+dependencies = [
+  "ffmpeg[x264,vpx,freetype,fontconfig,dav1d]",
+  "x264[asm,core]",
+]
+
+[package.metadata.vcpkg.target.aarch64-apple-darwin]
+triplet = "arm64-osx"
+dependencies = [
+  "ffmpeg[x264,vpx,freetype,fontconfig,dav1d]",
+  "x264[asm,core]",
+]
+
 [patch.crates-io]
 # Keep the Rust-side ort 2.0.0-rc.10 API required by paddle-ocr-rs while
 # allowing deployments to load the older ONNX Runtime 1.16 shared library.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 edition = "2021"
 
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@
 [![docs.rs](https://docs.rs/direct_play_nice/badge.svg)](https://docs.rs/direct_play_nice)
 [![CI](https://github.com/ns-mkusper/direct-play-nice/actions/workflows/ci.yml/badge.svg)](https://github.com/ns-mkusper/direct-play-nice/actions/workflows/ci.yml)
 
-<<<<<<< HEAD
 `direct-play-nice` is a cross-platform CLI tool that converts video files
 to profiles more likely to Direct Play across common streaming devices.
-=======
-`direct-play-nice` is a cross-platform CLI tool that converts video files to profiles more
-likely to Direct Play across common streaming devices.
->>>>>>> 03216f8 (docs(readme): describe direct-play-nice as cross-platform CLI tool)
 
 ## What Is Direct Play?
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@
 [![docs.rs](https://docs.rs/direct_play_nice/badge.svg)](https://docs.rs/direct_play_nice)
 [![CI](https://github.com/ns-mkusper/direct-play-nice/actions/workflows/ci.yml/badge.svg)](https://github.com/ns-mkusper/direct-play-nice/actions/workflows/ci.yml)
 
-`direct-play-nice` is a cross-platform CLI tool that converts video files to
-profiles more likely to Direct Play across common streaming devices.
+<<<<<<< HEAD
+`direct-play-nice` is a cross-platform CLI tool that converts video files
+to profiles more likely to Direct Play across common streaming devices.
+=======
+`direct-play-nice` is a cross-platform CLI tool that converts video files to profiles more
+likely to Direct Play across common streaming devices.
+>>>>>>> 03216f8 (docs(readme): describe direct-play-nice as cross-platform CLI tool)
 
 ## What Is Direct Play?
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,5 +1,17 @@
 # Installation
 
+## Prebuilt binaries
+
+Each GitHub release publishes platform archives and checksums built by
+`cargo-dist`:
+
+- `direct_play_nice-aarch64-apple-darwin.tar.xz`
+- `direct_play_nice-x86_64-apple-darwin.tar.xz`
+- `direct_play_nice-x86_64-unknown-linux-gnu.tar.xz`
+- `direct_play_nice-x86_64-pc-windows-msvc.zip`
+
+The release also includes shell and PowerShell installers.
+
 ## From crates.io
 
 ```bash

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,8 +11,8 @@ dependencies_update = true
 # create tags for the releases
 git_tag_enable = true
 
-# enable GitHub releases
-git_release_enable = true
+# cargo-dist owns GitHub releases so it can attach binary archives/checksums.
+git_release_enable = false
 
 # labels for the release PR
 pr_labels = ["release"]

--- a/src/subtitle_ocr/tests.rs
+++ b/src/subtitle_ocr/tests.rs
@@ -805,6 +805,7 @@ fn is_skippable_ort_runtime_error(msg: &str) -> bool {
     // CI runners often have an unexpected ORT runtime on PATH/LD path.
     // Skip these environment-specific failures so OCR logic tests remain stable.
     (lower.contains("libonnxruntime.so") && lower.contains("cannot open shared object file"))
+        || (lower.contains("libonnxruntime.dylib") && lower.contains("no such file"))
         || (lower.contains("onnxruntime.dll")
             && lower.contains("is not compatible with the onnx runtime binary found"))
         || lower.contains("expected getversionstring")


### PR DESCRIPTION
## Summary
- let cargo-dist own GitHub releases so it can attach platform archives, installers, and checksums
- keep release-plz responsible for version/tag creation while disabling release-plz GitHub releases
- dispatch the cargo-dist release workflow after release-plz creates new tags on `main`
- publish binaries for macOS Apple Silicon, macOS Intel, Linux x64, and Windows MSVC
- configure vcpkg FFmpeg targets for macOS Intel and Apple Silicon and link the required macOS media frameworks
- add PR coverage for macOS Intel and Apple Silicon alongside the existing Linux and Windows jobs
- harden CI by making sccache setup non-fatal and treating missing local ONNX Runtime dylibs as skippable runner environment failures
- fix README conflict markers that were breaking markdown checks
- document prebuilt release archives in the installation guide
- bump the crate to `0.1.0-beta.2` so merging this PR can issue a new prerelease tag/release

## Release behavior
- `v0.1.0-beta.1` already exists, so this PR bumps `Cargo.toml` to `0.1.0-beta.2`.
- On merge to `main`, `release-plz` should tag `v0.1.0-beta.2`.
- After the tag is created, the CD workflow dispatches `release.yml` for that tag.
- `release.yml` builds and publishes the cargo-dist binary artifacts/checksums to the GitHub Release.

## Validation
- `cargo dist plan --allow-dirty --output-format=json`
- `cargo metadata --locked --no-deps --format-version=1`
- `cargo fmt --all -- --check`
- `cargo dist manifest --artifacts=all --allow-dirty --output-format=json --no-local-paths`
- `cargo dist generate --mode=ci --check --allow-dirty`
- `npx --yes js-yaml .github/workflows/{ci,release,cd}.yml`
- `npx --yes markdownlint-cli2 $(git ls-files "*.md")`
- `git diff --check`

## Check status
- Latest PR run passes for Linux stable, Linux beta, Linux nightly, Windows MSVC, macOS Intel, macOS Apple Silicon, Cargo Audit, Secret Scan, Markdown Lint + Links, mdBook Build, benchmark runner smoke, release readiness, and the cargo-dist release plan.
- Expected PR-only skips: GPU OCR self-hosted job, benchmark publishing jobs, and cargo-dist publish artifact jobs.