### PR TITLE
Fix release runner labels

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,8 @@ git-fetch-with-cli = true
 [target.x86_64-pc-windows-msvc]
 rustflags = [
   "-C",
+  "target-feature=+crt-static",
+  "-C",
   "link-arg=Mfplat.lib",
   "-C",
   "link-arg=Strmiids.lib",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -91,6 +91,6 @@ RUST_LOG = "info"
 
 [target.x86_64-pc-windows-msvc.env]
 # Default triplet for vcpkg-rs on Windows; CI/local can override by exporting
-# VCPKGRS_TRIPLET to a different value (e.g., x64-windows-static-md).
-VCPKGRS_TRIPLET = "x64-windows-static-md"
+# VCPKGRS_TRIPLET to a different value (e.g., x64-windows-static).
+VCPKGRS_TRIPLET = "x64-windows-static"
 VCPKG_ROOT = "C\\\\src\\\\vcpkg"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -199,6 +199,17 @@ jobs:
       CARGO_TERM_COLOR: always
       VCPKG_ROOT: ${{ github.workspace }}/target/vcpkg
       VCPKGRS_TRIPLET: x64-windows-static
+      RUSTFLAGS: >-
+        -C target-feature=+crt-static
+        -C link-arg=Mfplat.lib
+        -C link-arg=Strmiids.lib
+        -C link-arg=Mfuuid.lib
+        -C link-arg=Bcrypt.lib
+        -C link-arg=Ncrypt.lib
+        -C link-arg=Crypt32.lib
+        -C link-arg=Secur32.lib
+        -C link-arg=Ole32.lib
+        -C link-arg=User32.lib
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -391,6 +402,7 @@ jobs:
         env:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
+          RUSTFLAGS: ${{ env.RUSTFLAGS }}
           DPN_OCR_GOLDEN: "1"
           DPN_OCR_MODEL_DIR: ${{ github.workspace }}\\target\\ocr-models
         run: |

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -198,7 +198,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       VCPKG_ROOT: ${{ github.workspace }}/target/vcpkg
-      VCPKGRS_TRIPLET: x64-windows-static-md
+      VCPKGRS_TRIPLET: x64-windows-static
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,17 @@ jobs:
       CARGO_TERM_COLOR: always
       VCPKG_ROOT: ${{ github.workspace }}/target/vcpkg
       VCPKGRS_TRIPLET: x64-windows-static
+      RUSTFLAGS: >-
+        -C target-feature=+crt-static
+        -C link-arg=Mfplat.lib
+        -C link-arg=Strmiids.lib
+        -C link-arg=Mfuuid.lib
+        -C link-arg=Bcrypt.lib
+        -C link-arg=Ncrypt.lib
+        -C link-arg=Crypt32.lib
+        -C link-arg=Secur32.lib
+        -C link-arg=Ole32.lib
+        -C link-arg=User32.lib
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -483,7 +494,9 @@ jobs:
         env:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
+          RUSTFLAGS: ${{ env.RUSTFLAGS }}
           RUSTDOCFLAGS: >-
+            -C target-feature=+crt-static
             -C link-arg=Mfplat.lib
             -C link-arg=Strmiids.lib
             -C link-arg=Mfuuid.lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       VCPKG_ROOT: ${{ github.workspace }}/target/vcpkg
-      VCPKGRS_TRIPLET: x64-windows-static-md
+      VCPKGRS_TRIPLET: x64-windows-static
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,7 @@ jobs:
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             export VCPKGRS_TRIPLET="x64-windows-static"
             export VCPKG_DEFAULT_TRIPLET="x64-windows-static"
+            export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=Mfplat.lib -C link-arg=Strmiids.lib -C link-arg=Mfuuid.lib -C link-arg=Bcrypt.lib -C link-arg=Ncrypt.lib -C link-arg=Crypt32.lib -C link-arg=Secur32.lib -C link-arg=Ole32.lib -C link-arg=User32.lib"
           fi
           # Actually do builds and make zips and whatnot
           cargo dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,11 @@ jobs:
         run: |
           ${{ matrix.packages_install }}
       - name: Build artifacts
+        shell: bash
         run: |
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-framework -C link-arg=Foundation -C link-arg=-framework -C link-arg=CoreAudio -C link-arg=-framework -C link-arg=AVFoundation -C link-arg=-framework -C link-arg=CoreGraphics -C link-arg=-framework -C link-arg=OpenGL -C link-arg=-framework -C link-arg=CoreImage -C link-arg=-framework -C link-arg=AppKit -C link-arg=-framework -C link-arg=AudioToolbox -C link-arg=-framework -C link-arg=CoreFoundation -C link-arg=-framework -C link-arg=CoreMedia -C link-arg=-framework -C link-arg=CoreVideo -C link-arg=-framework -C link-arg=CoreServices -C link-arg=-framework -C link-arg=Security -C link-arg=-framework -C link-arg=VideoToolbox"
+          fi
           # Actually do builds and make zips and whatnot
           cargo dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "cargo dist ran successfully"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,10 @@ jobs:
           if [[ "${RUNNER_OS}" == "macOS" ]]; then
             export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-framework -C link-arg=Foundation -C link-arg=-framework -C link-arg=CoreAudio -C link-arg=-framework -C link-arg=AVFoundation -C link-arg=-framework -C link-arg=CoreGraphics -C link-arg=-framework -C link-arg=OpenGL -C link-arg=-framework -C link-arg=CoreImage -C link-arg=-framework -C link-arg=AppKit -C link-arg=-framework -C link-arg=AudioToolbox -C link-arg=-framework -C link-arg=CoreFoundation -C link-arg=-framework -C link-arg=CoreMedia -C link-arg=-framework -C link-arg=CoreVideo -C link-arg=-framework -C link-arg=CoreServices -C link-arg=-framework -C link-arg=Security -C link-arg=-framework -C link-arg=VideoToolbox"
           fi
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            export VCPKGRS_TRIPLET="x64-windows-static-md"
+            export VCPKG_DEFAULT_TRIPLET="x64-windows-static-md"
+          fi
           # Actually do builds and make zips and whatnot
           cargo dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "cargo dist ran successfully"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,10 @@ jobs:
             target/vcpkg/vcpkg
           "restore-keys": |
             vcpkg-root-${{ runner.os }}-${{ join(matrix.targets, '_') }}-
+      - name: "Reset partial vcpkg workspace cache"
+        if: "steps.vcpkg-cache.outputs.cache-hit != 'true'"
+        shell: bash
+        run: rm -rf target/vcpkg
       - name: "Build vcpkg dependencies"
         if: "steps.vcpkg-cache.outputs.cache-hit != 'true'"
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             export VCPKGRS_TRIPLET="x64-windows-static"
             export VCPKG_DEFAULT_TRIPLET="x64-windows-static"
-            export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=Mfplat.lib -C link-arg=Strmiids.lib -C link-arg=Mfuuid.lib -C link-arg=Bcrypt.lib -C link-arg=Ncrypt.lib -C link-arg=Crypt32.lib -C link-arg=Secur32.lib -C link-arg=Ole32.lib -C link-arg=User32.lib"
+            export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static -C link-arg=Mfplat.lib -C link-arg=Strmiids.lib -C link-arg=Mfuuid.lib -C link-arg=Bcrypt.lib -C link-arg=Ncrypt.lib -C link-arg=Crypt32.lib -C link-arg=Secur32.lib -C link-arg=Ole32.lib -C link-arg=User32.lib"
           fi
           # Actually do builds and make zips and whatnot
           cargo dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,8 @@ jobs:
             export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-framework -C link-arg=Foundation -C link-arg=-framework -C link-arg=CoreAudio -C link-arg=-framework -C link-arg=AVFoundation -C link-arg=-framework -C link-arg=CoreGraphics -C link-arg=-framework -C link-arg=OpenGL -C link-arg=-framework -C link-arg=CoreImage -C link-arg=-framework -C link-arg=AppKit -C link-arg=-framework -C link-arg=AudioToolbox -C link-arg=-framework -C link-arg=CoreFoundation -C link-arg=-framework -C link-arg=CoreMedia -C link-arg=-framework -C link-arg=CoreVideo -C link-arg=-framework -C link-arg=CoreServices -C link-arg=-framework -C link-arg=Security -C link-arg=-framework -C link-arg=VideoToolbox"
           fi
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            export VCPKGRS_TRIPLET="x64-windows-static-md"
-            export VCPKG_DEFAULT_TRIPLET="x64-windows-static-md"
+            export VCPKGRS_TRIPLET="x64-windows-static"
+            export VCPKG_DEFAULT_TRIPLET="x64-windows-static"
           fi
           # Actually do builds and make zips and whatnot
           cargo dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
         id: "cargo-vcpkg-cache"
         uses: "actions/cache@v4"
         with:
-          "key": "cargo-vcpkg-${{ runner.os }}-v1"
+          "key": "cargo-vcpkg-${{ runner.os }}-${{ runner.arch }}-v1"
           "path": "~/.cargo/bin/cargo-vcpkg"
       - name: "Install vcpkg"
         if: "steps.cargo-vcpkg-cache.outputs.cache-hit != 'true'"
@@ -175,7 +175,7 @@ jobs:
         id: "vcpkg-cache"
         uses: "actions/cache@v4"
         with:
-          "key": "vcpkg-root-${{ runner.os }}-${{ hashFiles('Cargo.toml') }}"
+          "key": "vcpkg-root-${{ runner.os }}-${{ join(matrix.targets, '_') }}-${{ hashFiles('Cargo.toml') }}"
           "path": |
             target/vcpkg/.vcpkg-root
             target/vcpkg/downloads
@@ -186,7 +186,7 @@ jobs:
             target/vcpkg/triplets
             target/vcpkg/vcpkg
           "restore-keys": |
-            vcpkg-root-${{ runner.os }}-
+            vcpkg-root-${{ runner.os }}-${{ join(matrix.targets, '_') }}-
       - name: "Build vcpkg dependencies"
         if: "steps.vcpkg-cache.outputs.cache-hit != 'true'"
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,8 +153,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: "Install vcpkg build dependencies"
-        run: "sudo apt-get --assume-yes install nasm"
+      - name: "Install vcpkg build dependencies (Linux)"
+        if: runner.os == 'Linux'
+        run: "sudo apt-get update -y && sudo apt-get --assume-yes install nasm autoconf autoconf-archive automake libtool"
+      - name: "Install vcpkg build dependencies (macOS)"
+        if: runner.os == 'macOS'
+        run: "brew install nasm autoconf autoconf-archive automake libtool pkg-config"
+      - name: "Install vcpkg build dependencies (Windows)"
+        if: runner.os == 'Windows'
+        run: "choco install nasm strawberryperl -y"
       - name: "Cache cargo-vcpkg binary"
         id: "cargo-vcpkg-cache"
         uses: "actions/cache@v4"
@@ -182,7 +189,18 @@ jobs:
             vcpkg-root-${{ runner.os }}-
       - name: "Build vcpkg dependencies"
         if: "steps.vcpkg-cache.outputs.cache-hit != 'true'"
-        run: "cargo vcpkg --verbose build"
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if cargo vcpkg --verbose build; then
+              exit 0
+            fi
+            if [[ "$attempt" == "3" ]]; then
+              exit 1
+            fi
+            sleep $((attempt * 30))
+          done
         env:
           "CMAKE_BUILD_PARALLEL_LEVEL": 2
           "VCPKG_BINARY_SOURCES": "clear;x-gha,readwrite"
@@ -276,7 +294,7 @@ jobs:
   benchmark-runner-check:
     needs:
       - plan
-    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    if: ${{ needs.plan.outputs.publishing == 'true' && github.event_name != 'workflow_dispatch' }}
     runs-on: "ubuntu-22.04"
     permissions:
       contents: read
@@ -422,7 +440,22 @@ jobs:
           prefix-key: release-bench-v1
 
       - name: Build release binary
-        run: cargo build --release
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release --bin direct_play_nice
+          bin_path="$(find target -path '*/release/direct_play_nice' -type f | head -n1)"
+          if [[ -z "$bin_path" ]]; then
+            echo "::error title=Missing benchmark binary::cargo build did not produce direct_play_nice."
+            find target -maxdepth 4 -type f -name 'direct_play_nice*' -print || true
+            exit 1
+          fi
+          mkdir -p target/release
+          if [[ "$bin_path" != "target/release/direct_play_nice" ]]; then
+            cp "$bin_path" target/release/direct_play_nice
+          fi
+          chmod +x target/release/direct_play_nice
+          ls -l target/release/direct_play_nice
 
       - name: Validate benchmark source path
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ git = "https://github.com/microsoft/vcpkg.git"
 rev = "7147ac1294ef9647e8679e1183ac440a5d0a63b7"
 
 [package.metadata.vcpkg.target.x86_64-pc-windows-msvc]
-triplet = "x64-windows-static-md"
+triplet = "x64-windows-static"
 dependencies = [
   "ffmpeg[x264,vpx,freetype,fontconfig,nvcodec,dav1d,qsv,amf]",
   "x264[asm,core]",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,10 @@ github-build-setup = "../templates/build-setup.yml"
 
 [workspace.metadata.dist.github-custom-runners]
 global = "ubuntu-22.04"
+aarch64-apple-darwin = "macos-15"
+x86_64-apple-darwin = "macos-15-intel"
+x86_64-pc-windows-msvc = "windows-2022"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"
 
 [package.metadata.vcpkg]
 dependencies = [

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_VENDOR").as_deref() == Ok("apple") {
+        for framework in [
+            "AudioToolbox",
+            "CoreFoundation",
+            "CoreMedia",
+            "CoreVideo",
+            "Security",
+            "VideoToolbox",
+        ] {
+            println!("cargo:rustc-link-lib=framework={framework}");
+        }
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -11,4 +11,13 @@ fn main() {
             println!("cargo:rustc-link-lib=framework={framework}");
         }
     }
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        for lib in [
+            "Mfplat", "Strmiids", "Mfuuid", "Bcrypt", "Ncrypt", "Crypt32", "Secur32", "Ole32",
+            "User32",
+        ] {
+            println!("cargo:rustc-link-lib={lib}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- pin cargo-dist release artifact targets to current GitHub runner labels, including Apple Silicon macOS, Intel macOS, Linux, and Windows
- install per-OS vcpkg build prerequisites in the release workflow and retry transient vcpkg builds
- split release vcpkg caches by target/arch so macOS Intel and Apple Silicon do not restore each other
- reset non-exact release vcpkg workspace cache restores before building, avoiding stale or malformed restored vcpkg trees
- skip release-workflow benchmarks for manual release reruns while keeping the separate post-merge benchmark pipeline as the gate
- make the release benchmark build explicitly produce and verify the expected binary before running benchmarks
- add Apple framework linkage for FFmpeg/VideoToolbox release builds so macOS archives can build under cargo-dist
- align Windows release and CI builds on the `x64-windows-static` vcpkg triplet and static MSVC CRT so tests and cargo-dist link against the same FFmpeg libraries
- link the Windows system libraries required by static FFmpeg Schannel and Media Foundation objects from `build.rs`
- pass Windows system library link args directly through workflow `RUSTFLAGS` for cargo-dist and Windows CI builds

## Release
- version bumped to `0.1.0-beta.2`
- release tag: `v0.1.0-beta.2`
- release `v0.1.0-beta.2` is published as a prerelease
- published binaries include Apple Silicon macOS, Intel macOS, Linux, and Windows archives plus checksums, installers, source archive, and `dist-manifest.json`

## Validation
- `cargo fmt --all -- --check`
- `npx --yes js-yaml .github/workflows/release.yml`
- `npx --yes js-yaml .github/workflows/ci.yml`
- `npx --yes js-yaml .github/workflows/ci-full.yml`
- `cargo dist plan --tag v0.1.0-beta.2 --allow-dirty --output-format=json`
- `git diff --check`
- release workflow run `25121873148` passed for Linux, Apple Silicon macOS, Intel macOS, Windows, global artifacts, host, and announce jobs
- latest PR CI run `25124153446` passed Linux stable/beta/nightly, Windows MSVC, macOS Intel, and macOS Apple Silicon
- security, release-plan, release-readiness, and benchmark-runner-smoke checks passed
- auto-merge is enabled; GitHub is waiting on the required PR review before merging to `main`
