### PR TITLE
fix: expose crate feature groups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,19 @@ edition = "2021"
 
 
 [features]
-ffmpeg-cli-tests = []
+default = ["ffmpeg", "ocr"]
+ffmpeg = [
+  "rsmpeg/ffmpeg8",
+  "rsmpeg/link_vcpkg_ffmpeg",
+  "rusty_ffmpeg/link_vcpkg_ffmpeg",
+]
+ocr = [
+  "ort/std",
+  "ort/ndarray",
+  "ort/tracing",
+  "ort/load-dynamic",
+]
+ffmpeg-cli-tests = ["ffmpeg"]
 
 
 [dependencies]
@@ -21,20 +33,12 @@ env_logger = "0.11.3"
 log = "0.4.22"
 image = "0.25"
 paddle-ocr-rs = { version = "0.6.1", default-features = false }
-ort = { version = "=2.0.0-rc.10", default-features = false, features = [
-  "std",
-  "ndarray",
-  "tracing",
-  "load-dynamic",
-] }
+ort = { version = "=2.0.0-rc.10", default-features = false }
 sha2 = "0.10"
 serde_json = "1.0"
 # rsmpeg/rusty_ffmpeg track FFmpeg 8 as of 0.18/0.16.
-rsmpeg = { version = "0.18.0", default-features = false, features = [
-  "ffmpeg8",
-  "link_vcpkg_ffmpeg",
-] }
-rusty_ffmpeg = { version = "0.16.7", features = ["link_vcpkg_ffmpeg"] }
+rsmpeg = { version = "0.18.0", default-features = false }
+rusty_ffmpeg = "0.16.7"
 serde = { version = "1.0.204", features = ["derive"] }
 shlex = "1.3"
 strum = "0.26.3"


### PR DESCRIPTION
## Summary
- replace the single test-only crate feature with crate-level feature groups for the published build surface
- add `default = ["ffmpeg", "ocr"]` so the default crate behavior remains unchanged
- move FFmpeg and ONNX Runtime dependency feature wiring behind the package-level `ffmpeg` and `ocr` features
- keep `ffmpeg-cli-tests` for integration tests, now depending on `ffmpeg`

## Notes
- This does not make FFmpeg or OCR optional at the code level; the current application still requires both paths for normal builds.
- The goal is to make crates.io feature metadata reflect the crate-level build surface instead of only showing a test-only feature.

## Validation
- `cargo metadata --no-deps --format-version=1`
- `cargo check --all-features`
- `cargo check`
- `cargo check --features ffmpeg-cli-tests`
- `cargo package --allow-dirty --no-verify`
- `git diff --check`
