### PR TITLE
fix: publish concrete release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -624,17 +624,56 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - id: release-notes
+        name: Resolve GitHub Release notes
+        env:
+          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
+          RELEASE_TAG: "${{ needs.plan.outputs.tag }}"
+        shell: bash
+        run: |
+          set -euo pipefail
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          if bash scripts/extract_changelog_release_notes.sh "$RELEASE_TAG" "$notes_file"; then
+            echo "Using CHANGELOG.md notes for $RELEASE_TAG."
+          else
+            echo "::warning title=Using cargo-dist release notes::No concrete CHANGELOG.md section found for $RELEASE_TAG."
+            printf '%s\n' "$ANNOUNCEMENT_BODY" > "$notes_file"
+          fi
+          echo "notes-file=$notes_file" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
+          RELEASE_TAG: "${{ needs.plan.outputs.tag }}"
+          RELEASE_NOTES_FILE: "${{ steps.release-notes.outputs.notes-file }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          git fetch --force --tags origin
+          release_commit="$(git rev-list -n1 "$RELEASE_TAG" 2>/dev/null || true)"
+          if [[ -z "$release_commit" ]]; then
+            release_commit="$RELEASE_COMMIT"
+          fi
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          release_args=()
+          if [[ -n "$PRERELEASE_FLAG" ]]; then
+            release_args+=("$PRERELEASE_FLAG")
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" artifacts/* --clobber
+            gh release edit "$RELEASE_TAG" \
+              --target "$release_commit" \
+              "${release_args[@]}" \
+              --title "$ANNOUNCEMENT_TITLE" \
+              --notes-file "$RELEASE_NOTES_FILE"
+          else
+            gh release create "$RELEASE_TAG" \
+              --target "$release_commit" \
+              "${release_args[@]}" \
+              --title "$ANNOUNCEMENT_TITLE" \
+              --notes-file "$RELEASE_NOTES_FILE" \
+              artifacts/*
+          fi
 
   announce:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ All notable changes to this project will be documented in this file.
 
 - No changes yet.
 
+## [0.1.0-beta.2] - 2026-04-29
+
+### 📌 Beta 2 Highlights
+
+- Published cargo-dist release binaries for Apple Silicon macOS, Intel macOS,
+  Linux, and Windows.
+- Added workflow-dispatch release reruns by tag so binary publishing can be
+  recovered without creating a new source release.
+- Added PR CI coverage for macOS Intel, macOS Apple Silicon, and Windows MSVC.
+
+### ⚙️ Release Pipeline
+
+- Pinned cargo-dist target runner labels to the current GitHub-hosted runner
+  fleet, including `macos-15`, `macos-15-intel`, `windows-2022`, and
+  `ubuntu-22.04`.
+- Split release vcpkg caches by target and reset partial restored caches before
+  building to avoid stale or malformed vcpkg workspaces.
+- Skipped release-workflow benchmarks only for manual binary reruns while
+  keeping the post-merge benchmark workflow as the release gate.
+- Made the release benchmark path explicitly build and validate the expected
+  release binary before running benchmark jobs.
+
+### 🧱 Platform Linkage
+
+- Added macOS framework link flags required by FFmpeg and VideoToolbox release
+  builds.
+- Aligned Windows CI and release builds on the `x64-windows-static` vcpkg
+  triplet and static MSVC CRT.
+- Passed Windows system library link flags through release workflow `RUSTFLAGS`
+  so static FFmpeg Schannel and Media Foundation objects link under cargo-dist.
+
 ## [0.1.0-beta.1] - 2026-04-26
 
 ### 📌 Beta 1 Highlights

--- a/scripts/extract_changelog_release_notes.sh
+++ b/scripts/extract_changelog_release_notes.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:?usage: extract_changelog_release_notes.sh <tag> <output-file>}"
+out_file="${2:?usage: extract_changelog_release_notes.sh <tag> <output-file>}"
+version="${tag#v}"
+tmp_file="$(mktemp)"
+trimmed_file="$(mktemp)"
+trap 'rm -f "$tmp_file" "$trimmed_file"' EXIT
+
+awk -v version="$version" '
+  BEGIN { in_section = 0; found = 0 }
+  $0 ~ "^## \\[" version "\\]" {
+    in_section = 1
+    found = 1
+    next
+  }
+  in_section && $0 ~ "^## \\[" {
+    exit
+  }
+  in_section {
+    print
+  }
+  END {
+    if (!found) {
+      exit 42
+    }
+  }
+' CHANGELOG.md > "$tmp_file"
+
+awk '
+  NF { seen = 1 }
+  seen { lines[++n] = $0 }
+  END {
+    while (n > 0 && lines[n] == "") {
+      n--
+    }
+    for (i = 1; i <= n; i++) {
+      print lines[i]
+    }
+  }
+' "$tmp_file" > "$trimmed_file"
+
+if [[ ! -s "$trimmed_file" ]]; then
+  echo "No changelog notes found for $tag" >&2
+  exit 1
+fi
+
+if grep -Eq 'No changes yet|📋 Pending' "$trimmed_file"; then
+  echo "Refusing to use placeholder changelog notes for $tag" >&2
+  exit 1
+fi
+
+if ! grep -Eq '^- ' "$trimmed_file"; then
+  echo "No release-note bullets found for $tag" >&2
+  exit 1
+fi
+
+cp "$trimmed_file" "$out_file"


### PR DESCRIPTION
## Summary
- add a real `0.1.0-beta.2` changelog section for the binary release work
- add a small changelog-section extractor for release tags
- make the cargo-dist GitHub release step prefer matching `CHANGELOG.md` notes over generated placeholder text
- make manual release reruns update existing GitHub releases and clobber assets instead of only creating a new release
- resolve the release target from the requested tag so workflow-dispatch reruns do not point the release at the dispatch branch commit

## Notes
- After this merges, rerun the `Release` workflow for `v0.1.0-beta.2` to rewrite the existing GitHub release body with the concrete changelog section while preserving/re-uploading the binaries.
- The `-beta.2` suffix is still correctly treated as a prerelease by SemVer/GitHub.

## Validation
- `bash scripts/extract_changelog_release_notes.sh v0.1.0-beta.2 /tmp/direct-play-nice-beta2-notes.md`
- `npx --yes js-yaml .github/workflows/release.yml`
- `cargo dist plan --tag v0.1.0-beta.2 --allow-dirty --output-format=json`
- `git diff --check`
