### PR TITLE
ci: require changelog notes for releases

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -58,6 +58,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Validate matching changelog release notes
+        if: steps.changes.outputs.enforce == 'true'
+        shell: bash
+        run: bash scripts/validate_release_changelog.sh
+
       - name: Decide if merge will release
         if: steps.changes.outputs.enforce == 'true'
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 
 - No changes yet.
 
+## [0.1.0-beta.3] - 2026-05-04
+
+### ⚙️ Release Pipeline
+
+- Added a release-readiness check that requires concrete `CHANGELOG.md` notes
+  for the exact `Cargo.toml` version before release-impacting PRs can merge.
+- Reused the GitHub release-note extraction rules in PR validation so missing,
+  placeholder-only, or malformed changelog sections fail before tags are cut.
+- Documented that release PRs must include matching changelog notes alongside
+  version bumps.
+
 ## [0.1.0-beta.2] - 2026-04-29
 
 ### 📌 Beta 2 Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0-beta.3] - 2026-05-04
 
-### ⚙️ Release Pipeline
+### ⚙️ Release Validation
 
 - Added a release-readiness check that requires concrete `CHANGELOG.md` notes
   for the exact `Cargo.toml` version before release-impacting PRs can merge.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 edition = "2021"
 
 

--- a/docs/src/release-process.md
+++ b/docs/src/release-process.md
@@ -33,7 +33,8 @@ Use this process when cutting a new source and binary release.
 4. Open a PR with the version bump and changelog entry.
 
    The release-readiness workflow checks whether release metadata will be
-   updated on merge.
+   updated on merge and verifies that `CHANGELOG.md` already contains concrete
+   notes for the exact `Cargo.toml` version.
 
 ## Merge and Verify
 

--- a/scripts/validate_release_changelog.sh
+++ b/scripts/validate_release_changelog.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+crate_version="$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)"
+
+if [[ -z "$crate_version" ]]; then
+  echo "::error title=Release changelog check failed::Unable to parse crate version from Cargo.toml"
+  exit 1
+fi
+
+notes_file="$(mktemp)"
+trap 'rm -f "$notes_file"' EXIT
+
+if ! bash scripts/extract_changelog_release_notes.sh "v${crate_version}" "$notes_file"; then
+  echo "::error title=Release changelog check failed::CHANGELOG.md must contain concrete notes for v${crate_version} before release."
+  echo "Add a section like: ## [${crate_version}] - YYYY-MM-DD"
+  exit 1
+fi
+
+echo "Found concrete CHANGELOG.md notes for v${crate_version}."


### PR DESCRIPTION
## Summary
- add a release changelog validator for the current Cargo.toml version
- run it from Release Readiness so release-impacting PRs fail before merge if matching notes are missing or placeholder-only
- document the requirement in the release process

## Validation
- `bash scripts/validate_release_changelog.sh`
- `git diff --check`
