### PR TITLE
Add optional Servarr language redownload checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ All notable changes to this project will be documented in this file.
 
 - No changes yet.
 
+## [1.0.0-beta.1] - 2026-05-21
+
+### 📌 1.0 Beta 1 Highlights
+
+- Added opt-in Sonarr/Radarr language compliance checks that inspect imported
+  media for required audio languages before conversion or replacement.
+- Added safe, dry-run-first replacement workflows that grab verified language
+  candidates, blocklist superseded history items, and avoid blind redownloads.
+- Added periodic history and Sonarr inventory audits for delayed dubs and
+  current-library backlog cleanup, including focused episode-ID batches.
+- Added Radarr completed-pending force-import handling for language-better
+  replacements that Radarr would otherwise leave blocked by quality hierarchy.
+- Added opt-in stream-copy retagging for trusted untagged audio/subtitle streams
+  so English-native libraries with `und` metadata can be fixed without
+  redownloading.
+
+### 🧪 Language Validation
+
+- Added mocked Sonarr/Radarr API coverage for release selection, inventory
+  audits, targeted audits, dry-runs, no-candidate behavior, and Radarr
+  force-import side effects.
+- Added FFmpeg-backed retagging tests for unknown audio language metadata and
+  safeguards that explicit non-English language tags are not overwritten.
+
 ## [0.2.0-beta.1] - 2026-05-21
 
 ### 📌 Beta 4 Highlights

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "0.2.0-beta.1"
+version = "1.0.0-beta.1"
 edition = "2021"
 
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ servarr_language_candidate_policy = "custom-format-or-title"
 required_audio_languages = "eng"
 # Leave subtitle requirements empty unless subtitle completeness is a goal.
 required_subtitle_languages = ""
+# Optional: for trusted English-native libraries, retag untagged audio before
+# deciding the file is missing English audio.
+servarr_untagged_audio_language = "eng"
 ```
 
 To catch delayed dubs/subs that arrive after the first import, run the same

--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ ocr_format = "srt"
 ocr_write_srt_sidecar = false
 skip_codec_check = false
 
-# Optional: require imported media to contain specific audio/subtitle languages.
+# Optional: require imported media to contain English audio.
 # Start with dry-run while tuning candidate policy and custom formats.
 servarr_language_check = true
 servarr_language_dry_run = true
 servarr_language_candidate_policy = "custom-format-or-title"
-required_audio_languages = "eng,jpn"
-required_subtitle_languages = "eng"
+required_audio_languages = "eng"
+# Leave subtitle requirements empty unless subtitle completeness is a goal.
+required_subtitle_languages = ""
 ```
 
 To catch delayed dubs/subs that arrive after the first import, run the same

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ required_subtitle_languages = "eng"
 
 To catch delayed dubs/subs that arrive after the first import, run the same
 binary periodically with `--servarr-language-audit`. Use
-`--servarr-language-audit-scope inventory` for a Sonarr current-library sweep;
-see the
-[Sonarr/Radarr Integration](https://ns-mkusper.github.io/direct-play-nice/servarr.html)
-manual page for CLI/config examples.
+`--servarr-language-audit-scope inventory` for a Sonarr current-library sweep.
+Before applying broad language replacements, follow the
+[Safe language upgrade runbook](https://ns-mkusper.github.io/direct-play-nice/servarr.html#safe-language-upgrade-runbook)
+in the Sonarr/Radarr manual.
 
 ![Running as a custom script in Sonarr][sonarr-script-img]
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ required_subtitle_languages = "eng"
 ```
 
 To catch delayed dubs/subs that arrive after the first import, run the same
-binary periodically with `--servarr-language-audit`; see the
+binary periodically with `--servarr-language-audit`. Use
+`--servarr-language-audit-scope inventory` for a Sonarr current-library sweep;
+see the
 [Sonarr/Radarr Integration](https://ns-mkusper.github.io/direct-play-nice/servarr.html)
 manual page for CLI/config examples.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,20 @@ ocr_engine = "pp-ocr-v4"
 ocr_format = "srt"
 ocr_write_srt_sidecar = false
 skip_codec_check = false
+
+# Optional: require imported media to contain specific audio/subtitle languages.
+# Start with dry-run while tuning candidate policy and custom formats.
+servarr_language_check = true
+servarr_language_dry_run = true
+servarr_language_candidate_policy = "custom-format-or-title"
+required_audio_languages = "eng,jpn"
+required_subtitle_languages = "eng"
 ```
+
+To catch delayed dubs/subs that arrive after the first import, run the same
+binary periodically with `--servarr-language-audit`; see the
+[Sonarr/Radarr Integration](https://ns-mkusper.github.io/direct-play-nice/servarr.html)
+manual page for CLI/config examples.
 
 ![Running as a custom script in Sonarr][sonarr-script-img]
 

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -71,6 +71,10 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-api-key <KEY>` Sonarr/Radarr API key for mismatch replacement checks
 - `--servarr-language-dry-run` evaluate candidates without grabbing or
   blocklisting
+- `--servarr-untagged-audio-language <LANG>` opt-in language tag to apply to
+  untagged audio streams before redownload decisions
+- `--servarr-untagged-subtitle-language <LANG>` opt-in language tag to apply to
+  untagged subtitle streams before redownload decisions
 - `--servarr-language-candidate-policy <POLICY>`
   `strict|custom-format|custom-format-or-title|title-guess`
 - `--delete-source [<BOOL>]`

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -51,6 +51,11 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 
 - `--servarr-output-extension <EXTENSION>` (`match-input` supported)
 - `--servarr-output-suffix <servarr_output_suffix>`
+- `--servarr-language-check` enable pre-conversion language checks for Arr downloads
+- `--required-audio-languages <LANGS>` comma-separated ISO-639 tags such as `eng,jpn`
+- `--required-subtitle-languages <LANGS>` comma-separated ISO-639 tags such as `eng,spa`
+- `--servarr-api-url <URL>` Sonarr/Radarr base URL for mismatch redownload searches
+- `--servarr-api-key <KEY>` Sonarr/Radarr API key for mismatch redownload searches
 - `--delete-source [<BOOL>]`
 
 ## Subtitle OCR options

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -58,6 +58,8 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-language-audit-lookback-days <DAYS>` recent import window for
   history audit mode
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run
+- `--servarr-language-audit-episode-ids <IDS>` comma-separated Sonarr episode
+  IDs to audit instead of the full scope
 - `--servarr-language-check` enable pre-conversion language checks for Arr
   downloads
 - `--required-audio-languages <LANGS>` comma-separated ISO-639 tags such as

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -51,6 +51,9 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 
 - `--servarr-output-extension <EXTENSION>` (`match-input` supported)
 - `--servarr-output-suffix <servarr_output_suffix>`
+- `--servarr-language-audit` run a periodic Sonarr audit for delayed language upgrades
+- `--servarr-language-audit-lookback-days <DAYS>` recent import window for audit mode
+- `--servarr-language-audit-max-searches <N>` cap release searches per audit run
 - `--servarr-language-check` enable pre-conversion language checks for Arr downloads
 - `--required-audio-languages <LANGS>` comma-separated ISO-639 tags such as `eng,jpn`
 - `--required-subtitle-languages <LANGS>` comma-separated ISO-639 tags such as `eng,spa`

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -54,8 +54,10 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-language-check` enable pre-conversion language checks for Arr downloads
 - `--required-audio-languages <LANGS>` comma-separated ISO-639 tags such as `eng,jpn`
 - `--required-subtitle-languages <LANGS>` comma-separated ISO-639 tags such as `eng,spa`
-- `--servarr-api-url <URL>` Sonarr/Radarr base URL for mismatch redownload searches
-- `--servarr-api-key <KEY>` Sonarr/Radarr API key for mismatch redownload searches
+- `--servarr-api-url <URL>` Sonarr/Radarr base URL for mismatch replacement checks
+- `--servarr-api-key <KEY>` Sonarr/Radarr API key for mismatch replacement checks
+- `--servarr-language-dry-run` evaluate candidates without grabbing or blocklisting
+- `--servarr-language-candidate-policy <POLICY>` `strict|custom-format|custom-format-or-title|title-guess`
 - `--delete-source [<BOOL>]`
 
 ## Subtitle OCR options

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -51,16 +51,24 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 
 - `--servarr-output-extension <EXTENSION>` (`match-input` supported)
 - `--servarr-output-suffix <servarr_output_suffix>`
-- `--servarr-language-audit` run a periodic Sonarr/Radarr audit for delayed language upgrades
-- `--servarr-language-audit-lookback-days <DAYS>` recent import window for audit mode
+- `--servarr-language-audit` run a periodic Sonarr/Radarr audit for
+  delayed language upgrades
+- `--servarr-language-audit-lookback-days <DAYS>` recent import window for
+  audit mode
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run
-- `--servarr-language-check` enable pre-conversion language checks for Arr downloads
-- `--required-audio-languages <LANGS>` comma-separated ISO-639 tags such as `eng,jpn`
-- `--required-subtitle-languages <LANGS>` comma-separated ISO-639 tags such as `eng,spa`
-- `--servarr-api-url <URL>` Sonarr/Radarr base URL for mismatch replacement checks
+- `--servarr-language-check` enable pre-conversion language checks for Arr
+  downloads
+- `--required-audio-languages <LANGS>` comma-separated ISO-639 tags such as
+  `eng,jpn`
+- `--required-subtitle-languages <LANGS>` comma-separated ISO-639 tags such as
+  `eng,spa`
+- `--servarr-api-url <URL>` Sonarr/Radarr base URL for mismatch replacement
+  checks
 - `--servarr-api-key <KEY>` Sonarr/Radarr API key for mismatch replacement checks
-- `--servarr-language-dry-run` evaluate candidates without grabbing or blocklisting
-- `--servarr-language-candidate-policy <POLICY>` `strict|custom-format|custom-format-or-title|title-guess`
+- `--servarr-language-dry-run` evaluate candidates without grabbing or
+  blocklisting
+- `--servarr-language-candidate-policy <POLICY>`
+  `strict|custom-format|custom-format-or-title|title-guess`
 - `--delete-source [<BOOL>]`
 
 ## Subtitle OCR options

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -51,7 +51,7 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 
 - `--servarr-output-extension <EXTENSION>` (`match-input` supported)
 - `--servarr-output-suffix <servarr_output_suffix>`
-- `--servarr-language-audit` run a periodic Sonarr audit for delayed language upgrades
+- `--servarr-language-audit` run a periodic Sonarr/Radarr audit for delayed language upgrades
 - `--servarr-language-audit-lookback-days <DAYS>` recent import window for audit mode
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run
 - `--servarr-language-check` enable pre-conversion language checks for Arr downloads

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -53,8 +53,10 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-output-suffix <servarr_output_suffix>`
 - `--servarr-language-audit` run a periodic Sonarr/Radarr audit for
   delayed language upgrades
+- `--servarr-language-audit-scope <SCOPE>` choose `history` or Sonarr-only
+  `inventory` audit source
 - `--servarr-language-audit-lookback-days <DAYS>` recent import window for
-  audit mode
+  history audit mode
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run
 - `--servarr-language-check` enable pre-conversion language checks for Arr
   downloads

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -89,6 +89,9 @@ servarr_language_audit_max_searches = 20
 required_audio_languages = "eng"
 # Leave empty unless subtitle completeness is a goal.
 required_subtitle_languages = ""
+# Optional: for trusted English-native libraries, retag untagged audio before
+# deciding the file is missing English audio.
+servarr_untagged_audio_language = "eng"
 servarr_api_url = "http://127.0.0.1:8989"
 servarr_api_key = "..."
 
@@ -129,6 +132,16 @@ allowed; a file with English plus Japanese audio still satisfies
 `eng,jpn` only for libraries where preserving the original language alongside the
 dub is required. Leave `required_subtitle_languages` empty if missing subtitles
 are acceptable.
+
+Untagged streams are handled conservatively. By default, `und`/empty language
+metadata does not satisfy a required language. If a library is known to be
+English-native, set `servarr_untagged_audio_language = "eng"` or pass
+`--servarr-untagged-audio-language eng` to remux unknown audio streams with an
+English tag before DPN searches for replacement releases. The remux uses stream
+copy, writes through a temporary file, and never overwrites an explicit
+non-unknown language tag. `servarr_language_dry_run = true` only reports the
+retag action. Use `servarr_untagged_subtitle_language` only for trusted subtitle
+streams; DPN does not run speech recognition or globally infer `und = eng`.
 
 Candidate policies control how much DPN infers before a replacement is grabbed:
 

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -33,10 +33,12 @@ Example command in Sonarr custom script:
 
 Language checks are off by default. When enabled on a Sonarr/Radarr `Download`
 event, `direct-play-nice` inspects the imported file before conversion. If any
-configured audio or subtitle language is missing, conversion is skipped and a
-monitored search command is sent back to Sonarr/Radarr. The Arr service still
-applies its own quality/profile/indexer rules, so a replacement is only grabbed
-when an acceptable release is available.
+configured audio or subtitle language is missing, conversion is skipped and DPN
+asks Sonarr/Radarr for manual-search release results. It only grabs a specific
+replacement release when the returned release metadata verifies the required
+languages and the release is not rejected by Arr. If no verified candidate is
+available, DPN leaves the current file untouched and does not request a blind
+redownload.
 
 Example config:
 
@@ -51,6 +53,15 @@ servarr_api_key = "..."
 `servarr_api_url` and `servarr_api_key` can also be supplied with CLI flags or
 environment variables. Supported env names include `SONARR_URL`,
 `SONARR_API_KEY`, `RADARR_URL`, and `RADARR_API_KEY`.
+
+Before grabbing a verified replacement, DPN marks the current Arr history item as
+failed so the old release is blocklisted. It resolves that history item from the
+Arr download id when available, or from `DIRECT_PLAY_NICE_SONARR_HISTORY_ID` /
+`DIRECT_PLAY_NICE_RADARR_HISTORY_ID` if your wrapper provides it.
+
+Subtitle availability is intentionally conservative: DPN will not infer subtitle
+tracks from release titles. Subtitle requirements only trigger a specific grab
+when the release-search response contains explicit subtitle language metadata.
 
 ## Practical wrapper pattern
 

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -40,7 +40,44 @@ languages and the release is not rejected by Arr. If no verified candidate is
 available, DPN leaves the current file untouched and does not request a blind
 redownload.
 
-Example config:
+### CLI examples
+
+Dry-run first while tuning your matching rules. This inspects the imported file,
+queries Arr for replacement candidates when requirements are missing, and reports
+what would happen without grabbing or blocklisting anything:
+
+```bash
+/path/to/direct_play_nice \
+  --servarr-language-check \
+  --servarr-language-dry-run \
+  --servarr-language-candidate-policy custom-format-or-title \
+  --required-audio-languages eng,jpn \
+  --required-subtitle-languages eng \
+  --servarr-api-url http://127.0.0.1:8989 \
+  --servarr-api-key "$SONARR_API_KEY"
+```
+
+After dry-run output looks correct, remove `--servarr-language-dry-run` to allow
+DPN to grab the selected replacement and blocklist the old history item:
+
+```bash
+/path/to/direct_play_nice \
+  --servarr-language-check \
+  --servarr-language-candidate-policy custom-format-or-title \
+  --required-audio-languages eng,jpn \
+  --required-subtitle-languages eng \
+  --servarr-api-url http://127.0.0.1:8989 \
+  --servarr-api-key "$SONARR_API_KEY"
+```
+
+### Config-file example
+
+In a Sonarr/Radarr custom script, prefer keeping the command short and putting
+policy in the DPN config file:
+
+```bash
+/path/to/direct_play_nice --config-file /path/to/direct-play-nice-sonarr.toml
+```
 
 ```toml
 servarr_language_check = true
@@ -56,6 +93,13 @@ servarr_language_dry_run = true
 # strict only trusts explicit Arr language/subtitle metadata. custom-format-or-title
 # also trusts matching custom formats and strong tokens like Dual-Audio/Multi-Subs.
 servarr_language_candidate_policy = "custom-format-or-title"
+```
+
+For Radarr, use the Radarr URL/key instead:
+
+```toml
+servarr_api_url = "http://127.0.0.1:7878"
+servarr_api_key = "..."
 ```
 
 `servarr_api_url` and `servarr_api_key` can also be supplied with CLI flags or

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -127,6 +127,27 @@ The best-effort cache defaults to
 `~/.cache/direct-play-nice/servarr-language-cache.json`; override it with
 `DIRECT_PLAY_NICE_LANGUAGE_CACHE`.
 
+## Periodic language audit
+
+The Download-event hook only runs when Arr imports a file. To catch delayed dubs
+or subtitles that appear days later, run an audit from cron/systemd/launchd with
+no Arr custom-script environment variables:
+
+```bash
+/path/to/direct_play_nice \
+  --config-file /path/to/direct-play-nice-sonarr.toml \
+  --servarr-language-audit \
+  --servarr-language-audit-lookback-days 30 \
+  --servarr-language-audit-max-searches 20 \
+  --servarr-language-dry-run
+```
+
+Audit mode queries recent Sonarr imports, inspects the actual imported file
+language metadata, updates DPN's cache, and release-searches only missing-language
+items up to `--servarr-language-audit-max-searches`. Keep dry-run enabled while
+reviewing reports; remove `--servarr-language-dry-run` only when you want DPN to
+grab selected language-upgrade candidates and blocklist the old history item.
+
 ## Practical wrapper pattern
 
 For GPU OCR environments, keep a stable wrapper script as the command Sonarr

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -83,6 +83,7 @@ policy in the DPN config file:
 ```toml
 servarr_language_check = true
 servarr_language_audit = true
+servarr_language_audit_scope = "history"
 servarr_language_audit_lookback_days = 30
 servarr_language_audit_max_searches = 20
 required_audio_languages = "eng,jpn"
@@ -152,11 +153,17 @@ no Arr custom-script environment variables:
   --servarr-language-dry-run
 ```
 
-Audit mode queries recent Sonarr/Radarr imports, inspects the actual imported
-file language metadata, updates DPN's cache, and release-searches only
-missing-language items up to `--servarr-language-audit-max-searches`. In Radarr
-mode it also checks completed pending imports that Radarr refused for quality
-hierarchy reasons. Keep dry-run enabled while reviewing reports; remove
+By default, audit mode uses `--servarr-language-audit-scope history`: it queries
+recent Sonarr/Radarr imports, inspects the actual imported file language
+metadata, updates DPN's cache, and release-searches only missing-language items
+up to `--servarr-language-audit-max-searches`. Use
+`--servarr-language-audit-scope inventory` with Sonarr to inspect the current
+library inventory instead of only recent import history. Inventory scope walks
+series episode files, checks current media metadata, then uses each missing
+item's latest import history entry before any apply-mode grab/blocklist action.
+
+In Radarr mode DPN also checks completed pending imports that Radarr refused for
+quality hierarchy reasons. Keep dry-run enabled while reviewing reports; remove
 `--servarr-language-dry-run` only when you want DPN to grab selected
 language-upgrade candidates, blocklist the old history item, and force-import
 eligible Radarr pending replacements.

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -86,6 +86,8 @@ servarr_language_audit = true
 servarr_language_audit_scope = "history"
 servarr_language_audit_lookback_days = 30
 servarr_language_audit_max_searches = 20
+# Optional: limit a Sonarr audit to specific episode IDs.
+# servarr_language_audit_episode_ids = "123,456"
 required_audio_languages = "eng,jpn"
 required_subtitle_languages = "eng"
 servarr_api_url = "http://127.0.0.1:8989"
@@ -161,6 +163,8 @@ up to `--servarr-language-audit-max-searches`. Use
 library inventory instead of only recent import history. Inventory scope walks
 series episode files, checks current media metadata, then uses each missing
 item's latest import history entry before any apply-mode grab/blocklist action.
+For focused Sonarr batches, pass `--servarr-language-audit-episode-ids` with a
+comma-separated episode ID list.
 
 In Radarr mode DPN also checks completed pending imports that Radarr refused for
 quality hierarchy reasons. Keep dry-run enabled while reviewing reports; remove

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -52,8 +52,7 @@ what would happen without grabbing or blocklisting anything:
   --servarr-language-check \
   --servarr-language-dry-run \
   --servarr-language-candidate-policy custom-format-or-title \
-  --required-audio-languages eng,jpn \
-  --required-subtitle-languages eng \
+  --required-audio-languages eng \
   --servarr-api-url http://127.0.0.1:8989 \
   --servarr-api-key "$SONARR_API_KEY"
 ```
@@ -65,8 +64,7 @@ DPN to grab the selected replacement and blocklist the old history item:
 /path/to/direct_play_nice \
   --servarr-language-check \
   --servarr-language-candidate-policy custom-format-or-title \
-  --required-audio-languages eng,jpn \
-  --required-subtitle-languages eng \
+  --required-audio-languages eng \
   --servarr-api-url http://127.0.0.1:8989 \
   --servarr-api-key "$SONARR_API_KEY"
 ```
@@ -88,8 +86,9 @@ servarr_language_audit_lookback_days = 30
 servarr_language_audit_max_searches = 20
 # Optional: limit a Sonarr audit to specific episode IDs.
 # servarr_language_audit_episode_ids = "123,456"
-required_audio_languages = "eng,jpn"
-required_subtitle_languages = "eng"
+required_audio_languages = "eng"
+# Leave empty unless subtitle completeness is a goal.
+required_subtitle_languages = ""
 servarr_api_url = "http://127.0.0.1:8989"
 servarr_api_key = "..."
 
@@ -123,6 +122,13 @@ Radarr considers it a quality downgrade. Audit mode checks those pending imports
 when the pending file satisfies DPN's language policy, apply mode deletes the old
 movie-file entry, posts Radarr manual import, and removes the completed queue
 item without deleting the downloaded replacement.
+
+The default examples above require English audio only. Extra audio languages are
+allowed; a file with English plus Japanese audio still satisfies
+`required_audio_languages = "eng"`. Use stricter audio requirements such as
+`eng,jpn` only for libraries where preserving the original language alongside the
+dub is required. Leave `required_subtitle_languages` empty if missing subtitles
+are acceptable.
 
 Candidate policies control how much DPN infers before a replacement is grabbed:
 
@@ -211,7 +217,8 @@ observable batches. A safe operator workflow is:
    explicit Arr language metadata or strong custom-format/title evidence such as
    `Anime-multi-audio`, `anime-multi-sub`, `Dual-Audio`, `Multi-Audio`, or
    `Multi-Subs`. Treat unrelated rejections such as blocked indexers, unknown
-   series, or seed/availability failures as blockers.
+   series, or seed/availability failures as blockers. Do not add subtitle
+   requirements unless missing subtitles should trigger redownloads.
 
 4. **Apply only a focused batch.** Use Sonarr episode IDs from the dry-run logs
    to constrain the destructive run. Keep `--servarr-language-audit-max-searches`

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -48,6 +48,14 @@ required_audio_languages = "eng,jpn"
 required_subtitle_languages = "eng"
 servarr_api_url = "http://127.0.0.1:8989"
 servarr_api_key = "..."
+
+# Recommended while tuning rules. Logs the selected candidate but does not grab
+# or blocklist anything.
+servarr_language_dry_run = true
+
+# strict only trusts explicit Arr language/subtitle metadata. custom-format-or-title
+# also trusts matching custom formats and strong tokens like Dual-Audio/Multi-Subs.
+servarr_language_candidate_policy = "custom-format-or-title"
 ```
 
 `servarr_api_url` and `servarr_api_key` can also be supplied with CLI flags or
@@ -59,9 +67,21 @@ failed so the old release is blocklisted. It resolves that history item from the
 Arr download id when available, or from `DIRECT_PLAY_NICE_SONARR_HISTORY_ID` /
 `DIRECT_PLAY_NICE_RADARR_HISTORY_ID` if your wrapper provides it.
 
-Subtitle availability is intentionally conservative: DPN will not infer subtitle
-tracks from release titles. Subtitle requirements only trigger a specific grab
-when the release-search response contains explicit subtitle language metadata.
+Candidate policies control how much DPN infers before a replacement is grabbed:
+
+- `strict`: only explicit Arr language/subtitle metadata.
+- `custom-format`: explicit metadata plus matching Arr custom format names such
+  as `Anime-multi-audio` or `anime-multi-sub`.
+- `custom-format-or-title`: custom formats plus strong title tokens such as
+  `Dual-Audio`, `Multi-Audio`, `Multi-Subs`, or `MSubs`.
+- `title-guess`: looser title matching. Use dry-run first.
+
+DPN always treats the already-imported file differently from candidate releases:
+actual file compliance is based on FFmpeg stream metadata, then cached by DPN.
+The best-effort cache defaults to
+`$XDG_CACHE_HOME/direct-play-nice/servarr-language-cache.json` or
+`~/.cache/direct-play-nice/servarr-language-cache.json`; override it with
+`DIRECT_PLAY_NICE_LANGUAGE_CACHE`.
 
 ## Practical wrapper pattern
 

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -35,10 +35,11 @@ Language checks are off by default. When enabled on a Sonarr/Radarr `Download`
 event, `direct-play-nice` inspects the imported file before conversion. If any
 configured audio or subtitle language is missing, conversion is skipped and DPN
 asks Sonarr/Radarr for manual-search release results. It only grabs a specific
-replacement release when the returned release metadata verifies the required
-languages and the release is not rejected by Arr. If no verified candidate is
-available, DPN leaves the current file untouched and does not request a blind
-redownload.
+replacement release when the returned release metadata or configured candidate
+policy indicates the required languages. Existing-file/cutoff rejections may be
+overridden for language upgrades, but unrelated rejection reasons are still
+honored. If no verified candidate is available, DPN leaves the current file
+untouched and does not request a blind redownload.
 
 ### CLI examples
 
@@ -111,6 +112,12 @@ failed so the old release is blocklisted. It resolves that history item from the
 Arr download id when available, or from `DIRECT_PLAY_NICE_SONARR_HISTORY_ID` /
 `DIRECT_PLAY_NICE_RADARR_HISTORY_ID` if your wrapper provides it.
 
+For Radarr, a language-better file can be stuck as a completed queue item when
+Radarr considers it a quality downgrade. Audit mode checks those pending imports;
+when the pending file satisfies DPN's language policy, apply mode deletes the old
+movie-file entry, posts Radarr manual import, and removes the completed queue
+item without deleting the downloaded replacement.
+
 Candidate policies control how much DPN infers before a replacement is grabbed:
 
 - `strict`: only explicit Arr language/subtitle metadata.
@@ -142,11 +149,19 @@ no Arr custom-script environment variables:
   --servarr-language-dry-run
 ```
 
-Audit mode queries recent Sonarr imports, inspects the actual imported file
-language metadata, updates DPN's cache, and release-searches only missing-language
-items up to `--servarr-language-audit-max-searches`. Keep dry-run enabled while
-reviewing reports; remove `--servarr-language-dry-run` only when you want DPN to
-grab selected language-upgrade candidates and blocklist the old history item.
+Audit mode queries recent Sonarr/Radarr imports, inspects the actual imported
+file language metadata, updates DPN's cache, and release-searches only
+missing-language items up to `--servarr-language-audit-max-searches`. In Radarr
+mode it also checks completed pending imports that Radarr refused for quality
+hierarchy reasons. Keep dry-run enabled while reviewing reports; remove
+`--servarr-language-dry-run` only when you want DPN to grab selected
+language-upgrade candidates, blocklist the old history item, and force-import
+eligible Radarr pending replacements.
+
+This feature assumes DPN is the authority for language upgrades. To avoid Arr
+and DPN fighting each other, keep ordinary Arr quality-only upgrades conservative
+or disabled for libraries where DPN should make language-first replacement
+decisions.
 
 ## Practical wrapper pattern
 

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -29,7 +29,7 @@ Example command in Sonarr custom script:
 /path/to/direct_play_nice --config-file /path/to/direct-play-nice-sonarr.toml
 ```
 
-## Optional language mismatch redownload search
+## Optional language mismatch replacement
 
 Language checks are off by default. When enabled on a Sonarr/Radarr `Download`
 event, `direct-play-nice` inspects the imported file before conversion. If any
@@ -82,6 +82,9 @@ policy in the DPN config file:
 
 ```toml
 servarr_language_check = true
+servarr_language_audit = true
+servarr_language_audit_lookback_days = 30
+servarr_language_audit_max_searches = 20
 required_audio_languages = "eng,jpn"
 required_subtitle_languages = "eng"
 servarr_api_url = "http://127.0.0.1:8989"

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -29,6 +29,29 @@ Example command in Sonarr custom script:
 /path/to/direct_play_nice --config-file /path/to/direct-play-nice-sonarr.toml
 ```
 
+## Optional language mismatch redownload search
+
+Language checks are off by default. When enabled on a Sonarr/Radarr `Download`
+event, `direct-play-nice` inspects the imported file before conversion. If any
+configured audio or subtitle language is missing, conversion is skipped and a
+monitored search command is sent back to Sonarr/Radarr. The Arr service still
+applies its own quality/profile/indexer rules, so a replacement is only grabbed
+when an acceptable release is available.
+
+Example config:
+
+```toml
+servarr_language_check = true
+required_audio_languages = "eng,jpn"
+required_subtitle_languages = "eng"
+servarr_api_url = "http://127.0.0.1:8989"
+servarr_api_key = "..."
+```
+
+`servarr_api_url` and `servarr_api_key` can also be supplied with CLI flags or
+environment variables. Supported env names include `SONARR_URL`,
+`SONARR_API_KEY`, `RADARR_URL`, and `RADARR_API_KEY`.
+
 ## Practical wrapper pattern
 
 For GPU OCR environments, keep a stable wrapper script as the command Sonarr

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -177,6 +177,71 @@ and DPN fighting each other, keep ordinary Arr quality-only upgrades conservativ
 or disabled for libraries where DPN should make language-first replacement
 decisions.
 
+## Safe language upgrade runbook
+
+Language replacement is intentionally opt-in and should be rolled out in small,
+observable batches. A safe operator workflow is:
+
+1. **Start with a dry-run history audit.** This catches delayed dubs/subs for
+   recent imports without scanning the whole library:
+
+   ```bash
+   /path/to/direct_play_nice \
+     --config-file /path/to/direct-play-nice-sonarr.toml \
+     --servarr-language-audit \
+     --servarr-language-audit-scope history \
+     --servarr-language-audit-lookback-days 30 \
+     --servarr-language-audit-max-searches 20 \
+     --servarr-language-dry-run
+   ```
+
+2. **Use inventory dry-run for backlog discovery.** This is Sonarr-only and can
+   be slow on large libraries, so keep the search cap low while tuning:
+
+   ```bash
+   /path/to/direct_play_nice \
+     --config-file /path/to/direct-play-nice-sonarr.toml \
+     --servarr-language-audit \
+     --servarr-language-audit-scope inventory \
+     --servarr-language-audit-max-searches 25 \
+     --servarr-language-dry-run
+   ```
+
+3. **Review candidate evidence before apply mode.** Prefer candidates with
+   explicit Arr language metadata or strong custom-format/title evidence such as
+   `Anime-multi-audio`, `anime-multi-sub`, `Dual-Audio`, `Multi-Audio`, or
+   `Multi-Subs`. Treat unrelated rejections such as blocked indexers, unknown
+   series, or seed/availability failures as blockers.
+
+4. **Apply only a focused batch.** Use Sonarr episode IDs from the dry-run logs
+   to constrain the destructive run. Keep `--servarr-language-audit-max-searches`
+   at or below the number of intended items:
+
+   ```bash
+   /path/to/direct_play_nice \
+     --config-file /path/to/direct-play-nice-sonarr.toml \
+     --servarr-language-audit \
+     --servarr-language-audit-scope inventory \
+     --servarr-language-audit-episode-ids "12345,12346,12347" \
+     --servarr-language-audit-max-searches 3
+   ```
+
+5. **Watch Arr's queue and history.** A successful Sonarr language replacement
+   usually goes `grabbed` → `downloadFolderImported`; the imported file should
+   then show the required audio/subtitle languages in Arr media info. Some
+   candidates may remain queued/downloading for a while, and failed alternates in
+   history do not necessarily mean the current queued candidate failed.
+
+6. **Verify and repeat.** Re-run the same command with
+   `--servarr-language-dry-run`. Completed items should no longer be searched;
+   remaining missing items should either show a queued candidate, no candidate,
+   or a rejection reason to fix before another apply batch.
+
+For Radarr, keep the same dry-run-first workflow. In apply mode, DPN may
+force-import completed pending replacements that satisfy the language policy by
+deleting the old Radarr movie-file entry, posting manual import, and removing the
+stale completed queue item.
+
 ## Practical wrapper pattern
 
 For GPU OCR environments, keep a stable wrapper script as the command Sonarr

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,20 @@ pub struct Config {
     pub primary_video_criteria: Option<PrimaryVideoCriteria>,
     pub servarr_output_extension: Option<String>,
     pub servarr_output_suffix: Option<String>,
+    pub servarr_language_audit: Option<bool>,
+    pub servarr_language_audit_scope: Option<ServarrLanguageAuditScope>,
+    pub servarr_language_audit_lookback_days: Option<u32>,
+    pub servarr_language_audit_max_searches: Option<usize>,
+    pub servarr_language_audit_episode_ids: Option<String>,
+    pub servarr_language_check: Option<bool>,
+    pub required_audio_languages: Option<String>,
+    pub required_subtitle_languages: Option<String>,
+    pub servarr_api_url: Option<String>,
+    pub servarr_api_key: Option<String>,
+    pub servarr_language_dry_run: Option<bool>,
+    pub servarr_untagged_audio_language: Option<String>,
+    pub servarr_untagged_subtitle_language: Option<String>,
+    pub servarr_language_candidate_policy: Option<ServarrLanguageCandidatePolicy>,
     pub sub_mode: Option<SubMode>,
     pub subtitle_failure_policy: Option<SubtitleFailurePolicy>,
     pub ocr_default_language: Option<String>,
@@ -212,6 +226,34 @@ mod tests {
     }
 
     #[test]
+    fn parses_subtitle_ocr_settings() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            r#"
+            sub_mode = "force"
+            ocr_default_language = "spa"
+            ocr_engine = "external"
+            ocr_format = "ass"
+            ocr_external_command = "python3 /opt/ocr/run.py"
+            ocr_write_srt_sidecar = true
+            "#
+        )
+        .unwrap();
+
+        let cfg = read_from_path(tmp.path()).unwrap();
+        assert_eq!(cfg.sub_mode, Some(SubMode::Force));
+        assert_eq!(cfg.ocr_default_language.as_deref(), Some("spa"));
+        assert_eq!(cfg.ocr_engine, Some(OcrEngine::External));
+        assert_eq!(cfg.ocr_format, Some(OcrFormat::Ass));
+        assert_eq!(
+            cfg.ocr_external_command.as_deref(),
+            Some("python3 /opt/ocr/run.py")
+        );
+        assert_eq!(cfg.ocr_write_srt_sidecar, Some(true));
+    }
+
+    #[test]
     fn parses_servarr_language_check_settings() {
         let mut tmp = NamedTempFile::new().unwrap();
         write!(
@@ -265,34 +307,6 @@ mod tests {
             cfg.servarr_language_candidate_policy,
             Some(ServarrLanguageCandidatePolicy::CustomFormatOrTitle)
         );
-    }
-
-    #[test]
-    fn parses_subtitle_ocr_settings() {
-        let mut tmp = NamedTempFile::new().unwrap();
-        write!(
-            tmp,
-            r#"
-            sub_mode = "force"
-            ocr_default_language = "spa"
-            ocr_engine = "external"
-            ocr_format = "ass"
-            ocr_external_command = "python3 /opt/ocr/run.py"
-            ocr_write_srt_sidecar = true
-            "#
-        )
-        .unwrap();
-
-        let cfg = read_from_path(tmp.path()).unwrap();
-        assert_eq!(cfg.sub_mode, Some(SubMode::Force));
-        assert_eq!(cfg.ocr_default_language.as_deref(), Some("spa"));
-        assert_eq!(cfg.ocr_engine, Some(OcrEngine::External));
-        assert_eq!(cfg.ocr_format, Some(OcrFormat::Ass));
-        assert_eq!(
-            cfg.ocr_external_command.as_deref(),
-            Some("python3 /opt/ocr/run.py")
-        );
-        assert_eq!(cfg.ocr_write_srt_sidecar, Some(true));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,8 @@
 use crate::gpu::HwAccel;
 use crate::{
     AudioQuality, OcrEngine, OcrFormat, PrimaryVideoCriteria, ResizeBackend, ResizeQuality,
-    SubMode, SubtitleFailurePolicy, UnsupportedVideoPolicy, VideoCodecPreference, VideoQuality,
+    ServarrLanguageAuditScope, ServarrLanguageCandidatePolicy, SubMode, SubtitleFailurePolicy,
+    UnsupportedVideoPolicy, VideoCodecPreference, VideoQuality,
 };
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
@@ -32,11 +33,6 @@ pub struct Config {
     pub primary_video_criteria: Option<PrimaryVideoCriteria>,
     pub servarr_output_extension: Option<String>,
     pub servarr_output_suffix: Option<String>,
-    pub servarr_language_check: Option<bool>,
-    pub required_audio_languages: Option<String>,
-    pub required_subtitle_languages: Option<String>,
-    pub servarr_api_url: Option<String>,
-    pub servarr_api_key: Option<String>,
     pub sub_mode: Option<SubMode>,
     pub subtitle_failure_policy: Option<SubtitleFailurePolicy>,
     pub ocr_default_language: Option<String>,
@@ -221,16 +217,36 @@ mod tests {
         write!(
             tmp,
             r#"
+            servarr_language_audit = true
+            servarr_language_audit_scope = "inventory"
+            servarr_language_audit_lookback_days = 30
+            servarr_language_audit_max_searches = 20
+            servarr_language_audit_episode_ids = "1,2,3"
             servarr_language_check = true
             required_audio_languages = "eng,jpn"
             required_subtitle_languages = "eng,spa"
             servarr_api_url = "http://localhost:8989"
             servarr_api_key = "secret"
+            servarr_language_dry_run = true
+            servarr_untagged_audio_language = "eng"
+            servarr_untagged_subtitle_language = "eng"
+            servarr_language_candidate_policy = "custom-format-or-title"
             "#
         )
         .unwrap();
 
         let cfg = read_from_path(tmp.path()).unwrap();
+        assert_eq!(cfg.servarr_language_audit, Some(true));
+        assert_eq!(
+            cfg.servarr_language_audit_scope,
+            Some(ServarrLanguageAuditScope::Inventory)
+        );
+        assert_eq!(cfg.servarr_language_audit_lookback_days, Some(30));
+        assert_eq!(cfg.servarr_language_audit_max_searches, Some(20));
+        assert_eq!(
+            cfg.servarr_language_audit_episode_ids.as_deref(),
+            Some("1,2,3")
+        );
         assert_eq!(cfg.servarr_language_check, Some(true));
         assert_eq!(cfg.required_audio_languages.as_deref(), Some("eng,jpn"));
         assert_eq!(cfg.required_subtitle_languages.as_deref(), Some("eng,spa"));
@@ -239,6 +255,16 @@ mod tests {
             Some("http://localhost:8989")
         );
         assert_eq!(cfg.servarr_api_key.as_deref(), Some("secret"));
+        assert_eq!(cfg.servarr_language_dry_run, Some(true));
+        assert_eq!(cfg.servarr_untagged_audio_language.as_deref(), Some("eng"));
+        assert_eq!(
+            cfg.servarr_untagged_subtitle_language.as_deref(),
+            Some("eng")
+        );
+        assert_eq!(
+            cfg.servarr_language_candidate_policy,
+            Some(ServarrLanguageCandidatePolicy::CustomFormatOrTitle)
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,11 @@ pub struct Config {
     pub primary_video_criteria: Option<PrimaryVideoCriteria>,
     pub servarr_output_extension: Option<String>,
     pub servarr_output_suffix: Option<String>,
+    pub servarr_language_check: Option<bool>,
+    pub required_audio_languages: Option<String>,
+    pub required_subtitle_languages: Option<String>,
+    pub servarr_api_url: Option<String>,
+    pub servarr_api_key: Option<String>,
     pub sub_mode: Option<SubMode>,
     pub subtitle_failure_policy: Option<SubtitleFailurePolicy>,
     pub ocr_default_language: Option<String>,
@@ -208,6 +213,32 @@ mod tests {
             Some(val) => env::set_var("HOME", val),
             None => env::remove_var("HOME"),
         }
+    }
+
+    #[test]
+    fn parses_servarr_language_check_settings() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            r#"
+            servarr_language_check = true
+            required_audio_languages = "eng,jpn"
+            required_subtitle_languages = "eng,spa"
+            servarr_api_url = "http://localhost:8989"
+            servarr_api_key = "secret"
+            "#
+        )
+        .unwrap();
+
+        let cfg = read_from_path(tmp.path()).unwrap();
+        assert_eq!(cfg.servarr_language_check, Some(true));
+        assert_eq!(cfg.required_audio_languages.as_deref(), Some("eng,jpn"));
+        assert_eq!(cfg.required_subtitle_languages.as_deref(), Some("eng,spa"));
+        assert_eq!(
+            cfg.servarr_api_url.as_deref(),
+            Some("http://localhost:8989")
+        );
+        assert_eq!(cfg.servarr_api_key.as_deref(), Some("secret"));
     }
 
     #[test]

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -169,6 +169,18 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_dry_run") {
+        if let Some(dry_run) = cfg.servarr_language_dry_run {
+            args.servarr_language_dry_run = dry_run;
+        }
+    }
+
+    if !cli_value_provided(matches, "servarr_language_candidate_policy") {
+        if let Some(policy) = cfg.servarr_language_candidate_policy {
+            args.servarr_language_candidate_policy = policy;
+        }
+    }
+
     if !cli_value_provided(matches, "sub_mode") {
         if let Some(sub_mode) = cfg.sub_mode {
             args.sub_mode = sub_mode;
@@ -269,6 +281,10 @@ mod tests {
             required_subtitle_languages: Some("eng".to_string()),
             servarr_api_url: Some("http://localhost:8989".to_string()),
             servarr_api_key: Some("secret".to_string()),
+            servarr_language_dry_run: Some(true),
+            servarr_language_candidate_policy: Some(
+                crate::ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            ),
             ..Default::default()
         };
         apply_config_overrides(&mut args, &cfg, &matches);
@@ -280,6 +296,11 @@ mod tests {
             Some("http://localhost:8989")
         );
         assert_eq!(args.servarr_api_key.as_deref(), Some("secret"));
+        assert!(args.servarr_language_dry_run);
+        assert_eq!(
+            args.servarr_language_candidate_policy,
+            crate::ServarrLanguageCandidatePolicy::CustomFormatOrTitle
+        );
     }
 
     #[test]

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -139,6 +139,36 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_check") {
+        if let Some(enabled) = cfg.servarr_language_check {
+            args.servarr_language_check = enabled;
+        }
+    }
+
+    if !cli_value_provided(matches, "required_audio_languages") {
+        if let Some(languages) = cfg.required_audio_languages.as_ref() {
+            args.required_audio_languages = Some(languages.clone());
+        }
+    }
+
+    if !cli_value_provided(matches, "required_subtitle_languages") {
+        if let Some(languages) = cfg.required_subtitle_languages.as_ref() {
+            args.required_subtitle_languages = Some(languages.clone());
+        }
+    }
+
+    if !cli_value_provided(matches, "servarr_api_url") {
+        if let Some(url) = cfg.servarr_api_url.as_ref() {
+            args.servarr_api_url = Some(url.clone());
+        }
+    }
+
+    if !cli_value_provided(matches, "servarr_api_key") {
+        if let Some(api_key) = cfg.servarr_api_key.as_ref() {
+            args.servarr_api_key = Some(api_key.clone());
+        }
+    }
+
     if !cli_value_provided(matches, "sub_mode") {
         if let Some(sub_mode) = cfg.sub_mode {
             args.sub_mode = sub_mode;
@@ -228,6 +258,46 @@ mod tests {
         };
         apply_config_overrides(&mut args, &cfg, &matches);
         assert_eq!(args.video_quality, VideoQuality::P1080);
+    }
+
+    #[test]
+    fn applies_servarr_language_settings_from_config_when_not_set_in_cli() {
+        let (mut args, matches) = parse_args(&["direct_play_nice"]);
+        let cfg = config::Config {
+            servarr_language_check: Some(true),
+            required_audio_languages: Some("eng,jpn".to_string()),
+            required_subtitle_languages: Some("eng".to_string()),
+            servarr_api_url: Some("http://localhost:8989".to_string()),
+            servarr_api_key: Some("secret".to_string()),
+            ..Default::default()
+        };
+        apply_config_overrides(&mut args, &cfg, &matches);
+        assert!(args.servarr_language_check);
+        assert_eq!(args.required_audio_languages.as_deref(), Some("eng,jpn"));
+        assert_eq!(args.required_subtitle_languages.as_deref(), Some("eng"));
+        assert_eq!(
+            args.servarr_api_url.as_deref(),
+            Some("http://localhost:8989")
+        );
+        assert_eq!(args.servarr_api_key.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn cli_servarr_language_settings_take_precedence_over_config() {
+        let (mut args, matches) = parse_args(&[
+            "direct_play_nice",
+            "--servarr-language-check",
+            "--required-audio-languages",
+            "eng",
+        ]);
+        let cfg = config::Config {
+            servarr_language_check: Some(false),
+            required_audio_languages: Some("jpn".to_string()),
+            ..Default::default()
+        };
+        apply_config_overrides(&mut args, &cfg, &matches);
+        assert!(args.servarr_language_check);
+        assert_eq!(args.required_audio_languages.as_deref(), Some("eng"));
     }
 
     #[test]

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -139,6 +139,24 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_audit") {
+        if let Some(enabled) = cfg.servarr_language_audit {
+            args.servarr_language_audit = enabled;
+        }
+    }
+
+    if !cli_value_provided(matches, "servarr_language_audit_lookback_days") {
+        if let Some(days) = cfg.servarr_language_audit_lookback_days {
+            args.servarr_language_audit_lookback_days = days;
+        }
+    }
+
+    if !cli_value_provided(matches, "servarr_language_audit_max_searches") {
+        if let Some(max_searches) = cfg.servarr_language_audit_max_searches {
+            args.servarr_language_audit_max_searches = max_searches;
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_check") {
         if let Some(enabled) = cfg.servarr_language_check {
             args.servarr_language_check = enabled;
@@ -276,6 +294,9 @@ mod tests {
     fn applies_servarr_language_settings_from_config_when_not_set_in_cli() {
         let (mut args, matches) = parse_args(&["direct_play_nice"]);
         let cfg = config::Config {
+            servarr_language_audit: Some(true),
+            servarr_language_audit_lookback_days: Some(30),
+            servarr_language_audit_max_searches: Some(20),
             servarr_language_check: Some(true),
             required_audio_languages: Some("eng,jpn".to_string()),
             required_subtitle_languages: Some("eng".to_string()),
@@ -288,6 +309,9 @@ mod tests {
             ..Default::default()
         };
         apply_config_overrides(&mut args, &cfg, &matches);
+        assert!(args.servarr_language_audit);
+        assert_eq!(args.servarr_language_audit_lookback_days, 30);
+        assert_eq!(args.servarr_language_audit_max_searches, 20);
         assert!(args.servarr_language_check);
         assert_eq!(args.required_audio_languages.as_deref(), Some("eng,jpn"));
         assert_eq!(args.required_subtitle_languages.as_deref(), Some("eng"));

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -163,6 +163,12 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_audit_episode_ids") {
+        if let Some(ids) = cfg.servarr_language_audit_episode_ids.as_ref() {
+            args.servarr_language_audit_episode_ids = Some(ids.clone());
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_check") {
         if let Some(enabled) = cfg.servarr_language_check {
             args.servarr_language_check = enabled;
@@ -304,6 +310,7 @@ mod tests {
             servarr_language_audit_scope: Some(crate::ServarrLanguageAuditScope::Inventory),
             servarr_language_audit_lookback_days: Some(30),
             servarr_language_audit_max_searches: Some(20),
+            servarr_language_audit_episode_ids: Some("77,88".to_string()),
             servarr_language_check: Some(true),
             required_audio_languages: Some("eng,jpn".to_string()),
             required_subtitle_languages: Some("eng".to_string()),
@@ -323,6 +330,10 @@ mod tests {
         );
         assert_eq!(args.servarr_language_audit_lookback_days, 30);
         assert_eq!(args.servarr_language_audit_max_searches, 20);
+        assert_eq!(
+            args.servarr_language_audit_episode_ids.as_deref(),
+            Some("77,88")
+        );
         assert!(args.servarr_language_check);
         assert_eq!(args.required_audio_languages.as_deref(), Some("eng,jpn"));
         assert_eq!(args.required_subtitle_languages.as_deref(), Some("eng"));

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -145,6 +145,12 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_audit_scope") {
+        if let Some(scope) = cfg.servarr_language_audit_scope {
+            args.servarr_language_audit_scope = scope;
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_audit_lookback_days") {
         if let Some(days) = cfg.servarr_language_audit_lookback_days {
             args.servarr_language_audit_lookback_days = days;
@@ -295,6 +301,7 @@ mod tests {
         let (mut args, matches) = parse_args(&["direct_play_nice"]);
         let cfg = config::Config {
             servarr_language_audit: Some(true),
+            servarr_language_audit_scope: Some(crate::ServarrLanguageAuditScope::Inventory),
             servarr_language_audit_lookback_days: Some(30),
             servarr_language_audit_max_searches: Some(20),
             servarr_language_check: Some(true),
@@ -310,6 +317,10 @@ mod tests {
         };
         apply_config_overrides(&mut args, &cfg, &matches);
         assert!(args.servarr_language_audit);
+        assert_eq!(
+            args.servarr_language_audit_scope,
+            crate::ServarrLanguageAuditScope::Inventory
+        );
         assert_eq!(args.servarr_language_audit_lookback_days, 30);
         assert_eq!(args.servarr_language_audit_max_searches, 20);
         assert!(args.servarr_language_check);

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -205,6 +205,18 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_untagged_audio_language") {
+        if let Some(language) = cfg.servarr_untagged_audio_language.as_ref() {
+            args.servarr_untagged_audio_language = Some(language.clone());
+        }
+    }
+
+    if !cli_value_provided(matches, "servarr_untagged_subtitle_language") {
+        if let Some(language) = cfg.servarr_untagged_subtitle_language.as_ref() {
+            args.servarr_untagged_subtitle_language = Some(language.clone());
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_candidate_policy") {
         if let Some(policy) = cfg.servarr_language_candidate_policy {
             args.servarr_language_candidate_policy = policy;
@@ -317,6 +329,8 @@ mod tests {
             servarr_api_url: Some("http://localhost:8989".to_string()),
             servarr_api_key: Some("secret".to_string()),
             servarr_language_dry_run: Some(true),
+            servarr_untagged_audio_language: Some("eng".to_string()),
+            servarr_untagged_subtitle_language: Some("eng".to_string()),
             servarr_language_candidate_policy: Some(
                 crate::ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
             ),
@@ -343,6 +357,11 @@ mod tests {
         );
         assert_eq!(args.servarr_api_key.as_deref(), Some("secret"));
         assert!(args.servarr_language_dry_run);
+        assert_eq!(args.servarr_untagged_audio_language.as_deref(), Some("eng"));
+        assert_eq!(
+            args.servarr_untagged_subtitle_language.as_deref(),
+            Some("eng")
+        );
         assert_eq!(
             args.servarr_language_candidate_policy,
             crate::ServarrLanguageCandidatePolicy::CustomFormatOrTitle

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -17,7 +17,8 @@ use crate::gpu::HwAccel;
 use crate::transcoder::{AudioQuality, VideoCodecPreference, VideoQuality};
 use crate::types::{
     OcrEngine, OcrFormat, OutputFormat, PrimaryVideoCriteria, ResizeBackend, ResizeQuality,
-    StreamsFilter, SubMode, SubtitleFailurePolicy, UnsupportedVideoPolicy,
+    ServarrLanguageAuditScope, ServarrLanguageCandidatePolicy, StreamsFilter, SubMode,
+    SubtitleFailurePolicy, UnsupportedVideoPolicy,
 };
 
 pub(crate) use crate::cli::progress::ProgressTracker;
@@ -198,6 +199,47 @@ pub(crate) struct Args {
     )]
     pub(crate) servarr_output_suffix: String,
 
+    /// Run a periodic Sonarr language audit instead of handling a single Arr download event.
+    #[arg(
+        long = "servarr-language-audit",
+        default_value_t = false,
+        id = "servarr_language_audit"
+    )]
+    pub(crate) servarr_language_audit: bool,
+
+    /// Servarr audit source: recent import history or current library inventory.
+    #[arg(
+        long = "servarr-language-audit-scope",
+        value_enum,
+        default_value_t = ServarrLanguageAuditScope::History,
+        id = "servarr_language_audit_scope"
+    )]
+    pub(crate) servarr_language_audit_scope: ServarrLanguageAuditScope,
+
+    /// Number of recent days to inspect in history-scoped --servarr-language-audit mode.
+    #[arg(
+        long = "servarr-language-audit-lookback-days",
+        default_value_t = 30,
+        id = "servarr_language_audit_lookback_days"
+    )]
+    pub(crate) servarr_language_audit_lookback_days: u32,
+
+    /// Maximum number of missing-language items to release-search per audit run.
+    #[arg(
+        long = "servarr-language-audit-max-searches",
+        default_value_t = 20,
+        id = "servarr_language_audit_max_searches"
+    )]
+    pub(crate) servarr_language_audit_max_searches: usize,
+
+    /// Optional comma-separated Sonarr episode IDs to audit instead of the full scope.
+    #[arg(
+        long = "servarr-language-audit-episode-ids",
+        value_name = "IDS",
+        id = "servarr_language_audit_episode_ids"
+    )]
+    pub(crate) servarr_language_audit_episode_ids: Option<String>,
+
     /// Enable Sonarr/Radarr media language checks before conversion. Off by default.
     #[arg(
         long = "servarr-language-check",
@@ -222,13 +264,46 @@ pub(crate) struct Args {
     )]
     pub(crate) required_subtitle_languages: Option<String>,
 
-    /// Sonarr/Radarr base URL used to request a monitored redownload search after a language mismatch.
+    /// Sonarr/Radarr base URL used to inspect and grab specific replacement releases after a language mismatch.
     #[arg(long = "servarr-api-url", value_name = "URL", id = "servarr_api_url")]
     pub(crate) servarr_api_url: Option<String>,
 
-    /// Sonarr/Radarr API key used with --servarr-language-check redownload searches.
+    /// Sonarr/Radarr API key used with --servarr-language-check replacement handling.
     #[arg(long = "servarr-api-key", value_name = "KEY", id = "servarr_api_key")]
     pub(crate) servarr_api_key: Option<String>,
+
+    /// Evaluate Servarr language mismatches and replacement candidates without grabbing or blocklisting anything.
+    #[arg(
+        long = "servarr-language-dry-run",
+        default_value_t = false,
+        id = "servarr_language_dry_run"
+    )]
+    pub(crate) servarr_language_dry_run: bool,
+
+    /// Opt-in language tag to apply to untagged audio streams before redownload decisions (e.g. eng).
+    #[arg(
+        long = "servarr-untagged-audio-language",
+        value_name = "LANG",
+        id = "servarr_untagged_audio_language"
+    )]
+    pub(crate) servarr_untagged_audio_language: Option<String>,
+
+    /// Opt-in language tag to apply to untagged subtitle streams before redownload decisions (e.g. eng).
+    #[arg(
+        long = "servarr-untagged-subtitle-language",
+        value_name = "LANG",
+        id = "servarr_untagged_subtitle_language"
+    )]
+    pub(crate) servarr_untagged_subtitle_language: Option<String>,
+
+    /// Candidate confidence policy for language replacement searches.
+    #[arg(
+        long = "servarr-language-candidate-policy",
+        value_enum,
+        default_value_t = ServarrLanguageCandidatePolicy::Strict,
+        id = "servarr_language_candidate_policy"
+    )]
+    pub(crate) servarr_language_candidate_policy: ServarrLanguageCandidatePolicy,
 
     /// Subtitle handling mode: auto converts bitmap subs via OCR, force processes all subtitle streams as text, skip disables subtitle processing.
     #[arg(

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -198,6 +198,38 @@ pub(crate) struct Args {
     )]
     pub(crate) servarr_output_suffix: String,
 
+    /// Enable Sonarr/Radarr media language checks before conversion. Off by default.
+    #[arg(
+        long = "servarr-language-check",
+        default_value_t = false,
+        id = "servarr_language_check"
+    )]
+    pub(crate) servarr_language_check: bool,
+
+    /// Required audio languages for --servarr-language-check, comma-separated ISO-639 tags (e.g. eng,jpn).
+    #[arg(
+        long = "required-audio-languages",
+        value_name = "LANGS",
+        id = "required_audio_languages"
+    )]
+    pub(crate) required_audio_languages: Option<String>,
+
+    /// Required subtitle languages for --servarr-language-check, comma-separated ISO-639 tags (e.g. eng,spa).
+    #[arg(
+        long = "required-subtitle-languages",
+        value_name = "LANGS",
+        id = "required_subtitle_languages"
+    )]
+    pub(crate) required_subtitle_languages: Option<String>,
+
+    /// Sonarr/Radarr base URL used to request a monitored redownload search after a language mismatch.
+    #[arg(long = "servarr-api-url", value_name = "URL", id = "servarr_api_url")]
+    pub(crate) servarr_api_url: Option<String>,
+
+    /// Sonarr/Radarr API key used with --servarr-language-check redownload searches.
+    #[arg(long = "servarr-api-key", value_name = "KEY", id = "servarr_api_key")]
+    pub(crate) servarr_api_key: Option<String>,
+
     /// Subtitle handling mode: auto converts bitmap subs via OCR, force processes all subtitle streams as text, skip disables subtitle processing.
     #[arg(
         long = "sub-mode",

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,9 @@ pub(crate) use transcoder::{
     configure_ffmpeg_logging, AudioQuality, VideoCodecPreference, VideoQuality,
 };
 pub(crate) use types::{
-    OcrEngine, OcrFormat, PrimaryVideoCriteria, ResizeBackend, ResizeQuality, SubMode,
-    SubtitleFailurePolicy, UnsupportedVideoPolicy,
+    OcrEngine, OcrFormat, PrimaryVideoCriteria, ResizeBackend, ResizeQuality,
+    ServarrLanguageAuditScope, ServarrLanguageCandidatePolicy, SubMode, SubtitleFailurePolicy,
+    UnsupportedVideoPolicy,
 };
 
 #[cfg(test)]

--- a/src/servarr.rs
+++ b/src/servarr.rs
@@ -7,12 +7,13 @@ use std::ffi::CString;
 use std::path::{Path, PathBuf};
 
 mod api;
+mod cache;
 mod env_helpers;
 mod language;
 mod media_paths;
 mod path_policy;
 
-pub use api::ApiSettings;
+pub use api::{ApiSettings, RedownloadOptions};
 pub use language::{parse_language_list, LanguageRequirements};
 
 #[cfg(test)]
@@ -218,6 +219,7 @@ pub struct ArgsView<'a> {
     pub desired_suffix: &'a str,
     pub language_requirements: LanguageRequirements,
     pub api_settings: ApiSettings,
+    pub redownload_options: RedownloadOptions,
 }
 
 #[derive(Debug, Clone)]
@@ -333,6 +335,15 @@ fn prepare_download(
         for input_path in &input_paths {
             let report = language::check_file(input_path, &view.language_requirements)
                 .with_context(|| format!("checking languages for '{}'", input_path.display()))?;
+            if let Err(err) =
+                cache::record_assessment(kind, input_path, &view.language_requirements, &report)
+            {
+                warn!(
+                    "Failed to update DPN language assessment cache for '{}': {}",
+                    input_path.display(),
+                    err
+                );
+            }
             if !report.satisfied() {
                 language_mismatches.push((input_path.clone(), report));
             }
@@ -354,6 +365,7 @@ fn prepare_download(
             kind,
             &view.api_settings,
             &view.language_requirements,
+            view.redownload_options,
         )? {
             api::RedownloadOutcome::Grabbed { title } => {
                 return Ok(IntegrationPreparation::Skip {
@@ -368,6 +380,14 @@ fn prepare_download(
                     reason: format!(
                         "{} language requirements were not met, but no replacement was grabbed: {}. Leaving current file untouched.",
                         kind.label(), reason
+                    ),
+                });
+            }
+            api::RedownloadOutcome::DryRun { summary } => {
+                return Ok(IntegrationPreparation::Skip {
+                    reason: format!(
+                        "{} language requirements were not met; dry-run only: {}. Leaving current file untouched.",
+                        kind.label(), summary
                     ),
                 });
             }

--- a/src/servarr.rs
+++ b/src/servarr.rs
@@ -6,9 +6,14 @@ use std::env;
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
 
+mod api;
 mod env_helpers;
+mod language;
 mod media_paths;
 mod path_policy;
+
+pub use api::ApiSettings;
+pub use language::{parse_language_list, LanguageRequirements};
 
 #[cfg(test)]
 mod servarr_tests;
@@ -204,13 +209,15 @@ impl ReplacePlan {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 /// Borrowed view of CLI path-related arguments used by Servarr planning.
 pub struct ArgsView<'a> {
     pub has_input: bool,
     pub has_output: bool,
     pub desired_extension: &'a str,
     pub desired_suffix: &'a str,
+    pub language_requirements: LanguageRequirements,
+    pub api_settings: ApiSettings,
 }
 
 #[derive(Debug, Clone)]
@@ -310,6 +317,47 @@ fn prepare_download(
 
     let display_name = get_env_ignore_case(kind.title_var());
     let is_upgrade = get_env_ignore_case(kind.is_upgrade_var()).and_then(parse_boolish);
+
+    if view.language_requirements.enabled
+        && view.language_requirements.audio.is_empty()
+        && view.language_requirements.subtitles.is_empty()
+    {
+        warn!(
+            "{} language check is enabled but no required audio/subtitle languages were configured; continuing conversion.",
+            kind.label()
+        );
+    }
+
+    let mut language_mismatches = Vec::new();
+    if view.language_requirements.is_effective() {
+        for input_path in &input_paths {
+            let report = language::check_file(input_path, &view.language_requirements)
+                .with_context(|| format!("checking languages for '{}'", input_path.display()))?;
+            if !report.satisfied() {
+                language_mismatches.push((input_path.clone(), report));
+            }
+        }
+    }
+
+    if !language_mismatches.is_empty() {
+        for (path, report) in &language_mismatches {
+            warn!(
+                "{} language requirements not met for '{}': missing {} (present audio [{}], subtitles [{}]).",
+                kind.label(),
+                path.display(),
+                report.describe_missing(),
+                report.present_audio.join(", "),
+                report.present_subtitles.join(", ")
+            );
+        }
+        api::trigger_redownload_search(kind, &view.api_settings)?;
+        return Ok(IntegrationPreparation::Skip {
+            reason: format!(
+                "{} language requirements were not met; requested a monitored redownload search and skipped conversion.",
+                kind.label()
+            ),
+        });
+    }
 
     let mut plans = Vec::new();
 

--- a/src/servarr.rs
+++ b/src/servarr.rs
@@ -13,7 +13,7 @@ mod language;
 mod media_paths;
 mod path_policy;
 
-pub use api::{run_sonarr_language_audit, ApiSettings, AuditOptions, RedownloadOptions};
+pub use api::{run_language_audit, ApiSettings, AuditOptions, RedownloadOptions};
 pub use language::{parse_language_list, LanguageRequirements};
 
 #[cfg(test)]

--- a/src/servarr.rs
+++ b/src/servarr.rs
@@ -350,13 +350,28 @@ fn prepare_download(
                 report.present_subtitles.join(", ")
             );
         }
-        api::trigger_redownload_search(kind, &view.api_settings)?;
-        return Ok(IntegrationPreparation::Skip {
-            reason: format!(
-                "{} language requirements were not met; requested a monitored redownload search and skipped conversion.",
-                kind.label()
-            ),
-        });
+        match api::trigger_verified_redownload(
+            kind,
+            &view.api_settings,
+            &view.language_requirements,
+        )? {
+            api::RedownloadOutcome::Grabbed { title } => {
+                return Ok(IntegrationPreparation::Skip {
+                    reason: format!(
+                        "{} language requirements were not met; blacklisted the current download and grabbed verified replacement '{}'.",
+                        kind.label(), title
+                    ),
+                });
+            }
+            api::RedownloadOutcome::NoVerifiedRelease { reason } => {
+                return Ok(IntegrationPreparation::Skip {
+                    reason: format!(
+                        "{} language requirements were not met, but no replacement was grabbed: {}. Leaving current file untouched.",
+                        kind.label(), reason
+                    ),
+                });
+            }
+        }
     }
 
     let mut plans = Vec::new();

--- a/src/servarr.rs
+++ b/src/servarr.rs
@@ -14,7 +14,7 @@ mod media_paths;
 mod path_policy;
 
 pub use api::{run_language_audit, ApiSettings, AuditOptions, RedownloadOptions};
-pub use language::{parse_language_list, LanguageRequirements};
+pub use language::{parse_language_list, LanguageRequirements, UntaggedRetagOptions};
 
 #[cfg(test)]
 mod servarr_tests;
@@ -218,6 +218,7 @@ pub struct ArgsView<'a> {
     pub desired_extension: &'a str,
     pub desired_suffix: &'a str,
     pub language_requirements: LanguageRequirements,
+    pub untagged_retag: language::UntaggedRetagOptions,
     pub api_settings: ApiSettings,
     pub redownload_options: RedownloadOptions,
 }
@@ -333,8 +334,39 @@ fn prepare_download(
     let mut language_mismatches = Vec::new();
     if view.language_requirements.is_effective() {
         for input_path in &input_paths {
-            let report = language::check_file(input_path, &view.language_requirements)
+            let mut report = language::check_file(input_path, &view.language_requirements)
                 .with_context(|| format!("checking languages for '{}'", input_path.display()))?;
+            if !report.satisfied() && view.untagged_retag.enabled() {
+                match language::retag_unknown_streams(
+                    input_path,
+                    &view.language_requirements,
+                    &view.untagged_retag,
+                ) {
+                    Ok(retag) if retag.changed() => {
+                        info!(
+                            "{} {}retagged unknown stream language metadata for '{}': audio={}, subtitles={}",
+                            kind.label(),
+                            if retag.dry_run { "would have " } else { "" },
+                            input_path.display(),
+                            retag.audio_streams,
+                            retag.subtitle_streams
+                        );
+                        if !retag.dry_run {
+                            report = language::check_file(input_path, &view.language_requirements)
+                                .with_context(|| {
+                                    format!("re-checking languages for '{}'", input_path.display())
+                                })?;
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(err) => warn!(
+                        "{} failed to retag unknown stream language metadata for '{}': {}",
+                        kind.label(),
+                        input_path.display(),
+                        err
+                    ),
+                }
+            }
             if let Err(err) =
                 cache::record_assessment(kind, input_path, &view.language_requirements, &report)
             {

--- a/src/servarr.rs
+++ b/src/servarr.rs
@@ -13,7 +13,7 @@ mod language;
 mod media_paths;
 mod path_policy;
 
-pub use api::{ApiSettings, RedownloadOptions};
+pub use api::{run_sonarr_language_audit, ApiSettings, AuditOptions, RedownloadOptions};
 pub use language::{parse_language_list, LanguageRequirements};
 
 #[cfg(test)]

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -1,13 +1,18 @@
 //! Minimal Sonarr/Radarr API helpers used by optional language mismatch handling.
 
+use super::cache;
 use super::env_helpers::get_env_ignore_case;
-use super::language::{normalize_language_tag, LanguageRequirements};
+use super::language::{
+    normalize_language_tag, parse_language_tokens, report_from_present, LanguageCheckReport,
+    LanguageRequirements,
+};
 use super::IntegrationKind;
 use crate::ServarrLanguageCandidatePolicy;
 use anyhow::{anyhow, bail, Context, Result};
 use log::{info, warn};
 use serde_json::Value;
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 use std::time::Duration;
 use ureq::{Agent, AgentBuilder};
 
@@ -32,11 +37,155 @@ impl Default for RedownloadOptions {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuditOptions {
+    pub lookback_days: u32,
+    pub max_searches: usize,
+}
+
+impl Default for AuditOptions {
+    fn default() -> Self {
+        Self {
+            lookback_days: 30,
+            max_searches: 20,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AuditSummary {
+    pub checked: usize,
+    pub missing: usize,
+    pub searched: usize,
+    pub grabbed: usize,
+    pub dry_run: usize,
+    pub no_candidate: usize,
+    pub errors: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RedownloadOutcome {
     Grabbed { title: String },
     DryRun { summary: String },
     NoVerifiedRelease { reason: String },
+}
+
+pub fn run_sonarr_language_audit(
+    settings: &ApiSettings,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    audit_options: AuditOptions,
+) -> Result<AuditSummary> {
+    let client = ApiClient::from_settings(IntegrationKind::Sonarr, settings)?;
+    let records = client.sonarr_recent_import_history(audit_options.lookback_days)?;
+    let mut summary = AuditSummary::default();
+    let mut searched = 0usize;
+
+    for record in records {
+        let Some(episode_id) = history_episode_id(&record) else {
+            continue;
+        };
+        let Some(history_id) = record.get("id").and_then(Value::as_i64) else {
+            continue;
+        };
+        let episode = match client.sonarr_episode(episode_id) {
+            Ok(episode) => episode,
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr language audit could not fetch episode {}: {}",
+                    episode_id, err
+                );
+                continue;
+            }
+        };
+        let Some(file_id) = episode.get("episodeFileId").and_then(Value::as_i64) else {
+            continue;
+        };
+        let episode_file = match client.sonarr_episode_file(file_id) {
+            Ok(file) => file,
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr language audit could not fetch episode file {}: {}",
+                    file_id, err
+                );
+                continue;
+            }
+        };
+        summary.checked += 1;
+        let report = language_report_from_episode_file(&episode_file, requirements);
+        let path = episode_file
+            .get("path")
+            .and_then(Value::as_str)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(format!("sonarr:episodefile:{file_id}")));
+        if let Err(err) =
+            cache::record_assessment(IntegrationKind::Sonarr, &path, requirements, &report)
+        {
+            warn!(
+                "Sonarr language audit failed to update DPN cache for '{}': {}",
+                path.display(),
+                err
+            );
+        }
+        if report.satisfied() {
+            continue;
+        }
+        summary.missing += 1;
+        if searched >= audit_options.max_searches {
+            continue;
+        }
+        searched += 1;
+        summary.searched += 1;
+        match client.redownload_for_target(
+            Target::SonarrEpisode { episode_id },
+            history_id,
+            requirements,
+            redownload_options,
+        ) {
+            Ok(RedownloadOutcome::Grabbed { title }) => {
+                summary.grabbed += 1;
+                info!(
+                    "Sonarr language audit grabbed replacement for episode {}: {}",
+                    episode_id, title
+                );
+            }
+            Ok(RedownloadOutcome::DryRun { summary: details }) => {
+                summary.dry_run += 1;
+                info!(
+                    "Sonarr language audit dry-run for episode {}: {}",
+                    episode_id, details
+                );
+            }
+            Ok(RedownloadOutcome::NoVerifiedRelease { reason }) => {
+                summary.no_candidate += 1;
+                info!(
+                    "Sonarr language audit found no replacement for episode {}: {}",
+                    episode_id, reason
+                );
+            }
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr language audit replacement check failed for episode {}: {}",
+                    episode_id, err
+                );
+            }
+        }
+    }
+
+    info!(
+        "Sonarr language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, errors={}",
+        summary.checked,
+        summary.missing,
+        summary.searched,
+        summary.dry_run,
+        summary.grabbed,
+        summary.no_candidate,
+        summary.errors
+    );
+    Ok(summary)
 }
 
 pub fn trigger_verified_redownload(
@@ -162,6 +311,98 @@ impl ApiClient {
         })
     }
 
+    fn redownload_for_target(
+        &self,
+        target: Target,
+        history_id: i64,
+        requirements: &LanguageRequirements,
+        options: RedownloadOptions,
+    ) -> Result<RedownloadOutcome> {
+        let releases = self.search_releases(&target)?;
+        let Some(release) =
+            select_verified_release(&releases, requirements, options.candidate_policy)
+        else {
+            return Ok(RedownloadOutcome::NoVerifiedRelease {
+                reason: format!(
+                    "{} manual search returned no approved release matching {:?} candidate policy for required audio{} languages",
+                    self.kind.label(),
+                    options.candidate_policy,
+                    if requirements.subtitles.is_empty() { "" } else { "/subtitle" }
+                ),
+            });
+        };
+        let title = release_title(release).unwrap_or_else(|| "<unknown release>".to_string());
+        let evidence = release_match_evidence(release, requirements, options.candidate_policy);
+        if options.dry_run {
+            return Ok(RedownloadOutcome::DryRun {
+                summary: format!(
+                    "would grab '{}' using {:?} policy ({}) and then blocklist history item {}{}",
+                    title,
+                    options.candidate_policy,
+                    evidence,
+                    history_id,
+                    if release_rejections_are_only_existing_file_cutoff(release) {
+                        "; accepting Arr's existing-file/cutoff rejection as a language-upgrade override"
+                    } else {
+                        ""
+                    }
+                ),
+            });
+        }
+        self.grab_release(release)?;
+        self.mark_history_failed(history_id)?;
+        Ok(RedownloadOutcome::Grabbed { title })
+    }
+
+    fn sonarr_recent_import_history(&self, lookback_days: u32) -> Result<Vec<Value>> {
+        let mut out = Vec::new();
+        let min_day = current_day_number().saturating_sub(lookback_days as i64);
+        for page in 1..=10 {
+            let endpoint = format!(
+                "{}/api/v3/history?page={page}&pageSize=100&sortKey=date&sortDirection=descending&includeSeries=true&includeEpisode=true",
+                self.base_url
+            );
+            let response = self.get(&endpoint)?;
+            let records = response
+                .get("records")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if records.is_empty() {
+                break;
+            }
+            let mut saw_old = false;
+            for record in records {
+                if let Some(day) = record
+                    .get("date")
+                    .and_then(Value::as_str)
+                    .and_then(iso_day_number)
+                {
+                    if day < min_day {
+                        saw_old = true;
+                        continue;
+                    }
+                }
+                if record.get("eventType").and_then(Value::as_str) == Some("downloadFolderImported")
+                {
+                    out.push(record);
+                }
+            }
+            if saw_old {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    fn sonarr_episode(&self, episode_id: i64) -> Result<Value> {
+        self.get(&format!("{}/api/v3/episode/{}", self.base_url, episode_id))
+    }
+
+    fn sonarr_episode_file(&self, file_id: i64) -> Result<Value> {
+        self.get(&format!("{}/api/v3/episodefile/{}", self.base_url, file_id))
+    }
+
     fn grab_release(&self, release: &Value) -> Result<()> {
         let endpoint = format!("{}/api/v3/release", self.base_url);
         self.post_json(&endpoint, release)
@@ -241,6 +482,64 @@ fn read_json_response(response: ureq::Response) -> Result<Value> {
         return Ok(Value::Null);
     }
     serde_json::from_str(&text).context("parsing JSON response")
+}
+
+fn history_episode_id(record: &Value) -> Option<i64> {
+    record
+        .get("episode")
+        .and_then(|episode| episode.get("id"))
+        .and_then(Value::as_i64)
+        .or_else(|| record.get("episodeId").and_then(Value::as_i64))
+}
+
+fn language_report_from_episode_file(
+    episode_file: &Value,
+    requirements: &LanguageRequirements,
+) -> LanguageCheckReport {
+    let media = episode_file.get("mediaInfo").unwrap_or(&Value::Null);
+    let audio = media
+        .get("audioLanguages")
+        .and_then(Value::as_str)
+        .map(parse_language_tokens)
+        .unwrap_or_else(|| {
+            let mut out = BTreeSet::new();
+            collect_language_values(episode_file.get("languages"), &mut out);
+            out.into_iter().collect()
+        });
+    let subtitles = media
+        .get("subtitles")
+        .and_then(Value::as_str)
+        .map(parse_language_tokens)
+        .unwrap_or_default();
+    report_from_present(audio, subtitles, requirements)
+}
+
+fn current_day_number() -> i64 {
+    let unix_days = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+        / 86_400;
+    unix_days + days_from_civil(1970, 1, 1)
+}
+
+fn iso_day_number(value: &str) -> Option<i64> {
+    let date = value.get(0..10)?;
+    let mut parts = date.split('-');
+    let year = parts.next()?.parse().ok()?;
+    let month = parts.next()?.parse().ok()?;
+    let day = parts.next()?.parse().ok()?;
+    Some(days_from_civil(year, month, day))
+}
+
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let y = year - if month <= 2 { 1 } else { 0 };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = month + if month > 2 { -3 } else { 9 };
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -429,6 +429,7 @@ fn url_encode(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockito::Matcher;
     use serde_json::json;
     use std::env;
     use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -447,6 +448,156 @@ mod tests {
             vec![10, 11, 12, 13, 14]
         );
         env::remove_var("sonarr_episodefile_episodeids");
+    }
+
+    #[test]
+    fn sonarr_verified_redownload_grabs_specific_release_then_blocklists_old_history() {
+        let _guard = env_lock();
+        env::set_var("sonarr_episode_id", "77");
+        env::set_var("DIRECT_PLAY_NICE_SONARR_HISTORY_ID", "1234");
+
+        let mut server = mockito::Server::new();
+        let release = json!({
+            "title": "verified replacement",
+            "guid": "abc",
+            "indexerId": 1,
+            "rejected": false,
+            "languages": [{"name": "English"}]
+        });
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "77".into()))
+            .with_status(200)
+            .with_body(json!([release]).to_string())
+            .create();
+        let grab = server
+            .mock("POST", "/api/v3/release")
+            .match_header("x-api-key", "test-key")
+            .with_status(200)
+            .with_body("{}")
+            .create();
+        let blocklist = server
+            .mock("POST", "/api/v3/history/failed/1234")
+            .match_header("x-api-key", "test-key")
+            .with_status(200)
+            .with_body("{}")
+            .create();
+
+        let outcome = trigger_verified_redownload(
+            IntegrationKind::Sonarr,
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string()],
+                subtitles: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            RedownloadOutcome::Grabbed {
+                title: "verified replacement".to_string()
+            }
+        );
+        search.assert();
+        grab.assert();
+        blocklist.assert();
+
+        env::remove_var("sonarr_episode_id");
+        env::remove_var("DIRECT_PLAY_NICE_SONARR_HISTORY_ID");
+    }
+
+    #[test]
+    fn does_not_grab_or_blocklist_when_no_verified_release_exists() {
+        let _guard = env_lock();
+        env::set_var("radarr_movie_id", "88");
+        env::set_var("DIRECT_PLAY_NICE_RADARR_HISTORY_ID", "4321");
+
+        let mut server = mockito::Server::new();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("movieId".into(), "88".into()))
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "title": "wrong language",
+                    "rejected": false,
+                    "languages": [{"name": "French"}]
+                }])
+                .to_string(),
+            )
+            .create();
+
+        let outcome = trigger_verified_redownload(
+            IntegrationKind::Radarr,
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string()],
+                subtitles: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(
+            outcome,
+            RedownloadOutcome::NoVerifiedRelease { .. }
+        ));
+        search.assert();
+
+        env::remove_var("radarr_movie_id");
+        env::remove_var("DIRECT_PLAY_NICE_RADARR_HISTORY_ID");
+    }
+
+    #[test]
+    fn refuses_to_grab_when_old_history_cannot_be_identified() {
+        let _guard = env_lock();
+        env::set_var("sonarr_episode_id", "77");
+        env::remove_var("DIRECT_PLAY_NICE_SONARR_HISTORY_ID");
+        env::remove_var("sonarr_download_id");
+
+        let mut server = mockito::Server::new();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "77".into()))
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "title": "verified replacement",
+                    "rejected": false,
+                    "languages": [{"name": "English"}]
+                }])
+                .to_string(),
+            )
+            .create();
+
+        let err = trigger_verified_redownload(
+            IntegrationKind::Sonarr,
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string()],
+                subtitles: Vec::new(),
+            },
+        )
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("could not identify the current download history record"));
+        search.assert();
+
+        env::remove_var("sonarr_episode_id");
     }
 
     #[test]

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -3,6 +3,7 @@
 use super::env_helpers::get_env_ignore_case;
 use super::language::{normalize_language_tag, LanguageRequirements};
 use super::IntegrationKind;
+use crate::ServarrLanguageCandidatePolicy;
 use anyhow::{anyhow, bail, Context, Result};
 use log::{info, warn};
 use serde_json::Value;
@@ -14,9 +15,25 @@ pub struct ApiSettings {
     pub api_key: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RedownloadOptions {
+    pub dry_run: bool,
+    pub candidate_policy: ServarrLanguageCandidatePolicy,
+}
+
+impl Default for RedownloadOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RedownloadOutcome {
     Grabbed { title: String },
+    DryRun { summary: String },
     NoVerifiedRelease { reason: String },
 }
 
@@ -24,15 +41,18 @@ pub fn trigger_verified_redownload(
     kind: IntegrationKind,
     settings: &ApiSettings,
     requirements: &LanguageRequirements,
+    options: RedownloadOptions,
 ) -> Result<RedownloadOutcome> {
     let client = ApiClient::from_settings(kind, settings)?;
     let target = Target::from_env(kind)?;
     let releases = client.search_releases(&target)?;
-    let Some(release) = select_verified_release(&releases, requirements) else {
+    let Some(release) = select_verified_release(&releases, requirements, options.candidate_policy)
+    else {
         return Ok(RedownloadOutcome::NoVerifiedRelease {
             reason: format!(
-                "{} manual search returned no approved release with verified required audio{} languages",
+                "{} manual search returned no approved release matching {:?} candidate policy for required audio{} languages",
                 kind.label(),
+                options.candidate_policy,
                 if requirements.subtitles.is_empty() {
                     ""
                 } else {
@@ -42,6 +62,17 @@ pub fn trigger_verified_redownload(
         });
     };
 
+    let title = release_title(release).unwrap_or_else(|| "<unknown release>".to_string());
+    let evidence = release_match_evidence(release, requirements, options.candidate_policy);
+    if options.dry_run {
+        return Ok(RedownloadOutcome::DryRun {
+            summary: format!(
+                "would grab '{}' using {:?} policy ({}) and then blocklist the current history item if identifiable",
+                title, options.candidate_policy, evidence
+            ),
+        });
+    }
+
     let Some(history_id) = client.find_current_history_id(kind)? else {
         bail!(
             "{} found a verified replacement but could not identify the current download history record to blacklist; refusing to grab replacement.",
@@ -49,7 +80,6 @@ pub fn trigger_verified_redownload(
         );
     };
 
-    let title = release_title(release).unwrap_or_else(|| "<unknown release>".to_string());
     client.grab_release(release)?;
     client.mark_history_failed(history_id)?;
     info!(
@@ -233,11 +263,12 @@ impl Target {
 fn select_verified_release<'a>(
     releases: &'a [Value],
     requirements: &LanguageRequirements,
+    policy: ServarrLanguageCandidatePolicy,
 ) -> Option<&'a Value> {
     releases
         .iter()
         .filter(|release| release_is_grabbable(release))
-        .filter(|release| release_satisfies_languages(release, requirements))
+        .filter(|release| release_satisfies_languages(release, requirements, policy))
         .max_by_key(|release| release_score(release))
 }
 
@@ -251,26 +282,71 @@ fn release_is_grabbable(release: &Value) -> bool {
     true
 }
 
-fn release_satisfies_languages(release: &Value, requirements: &LanguageRequirements) -> bool {
-    let langs = release_languages(release);
-    let missing_audio = requirements.audio.iter().any(|lang| !langs.contains(lang));
-    if missing_audio {
-        return false;
-    }
+fn release_satisfies_languages(
+    release: &Value,
+    requirements: &LanguageRequirements,
+    policy: ServarrLanguageCandidatePolicy,
+) -> bool {
+    let audio_ok = release_audio_satisfies(release, requirements, policy);
+    let subtitles_ok = release_subtitles_satisfy(release, requirements, policy);
+    audio_ok && subtitles_ok
+}
 
+fn release_audio_satisfies(
+    release: &Value,
+    requirements: &LanguageRequirements,
+    policy: ServarrLanguageCandidatePolicy,
+) -> bool {
+    if requirements.audio.is_empty() {
+        return true;
+    }
+    let langs = release_languages(release);
+    if requirements.audio.iter().all(|lang| langs.contains(lang)) {
+        return true;
+    }
+    match policy {
+        ServarrLanguageCandidatePolicy::Strict => false,
+        ServarrLanguageCandidatePolicy::CustomFormat => {
+            custom_formats_indicate_audio(release, &requirements.audio)
+        }
+        ServarrLanguageCandidatePolicy::CustomFormatOrTitle => {
+            custom_formats_indicate_audio(release, &requirements.audio)
+                || title_indicates_audio(release, &requirements.audio, false)
+        }
+        ServarrLanguageCandidatePolicy::TitleGuess => {
+            custom_formats_indicate_audio(release, &requirements.audio)
+                || title_indicates_audio(release, &requirements.audio, true)
+        }
+    }
+}
+
+fn release_subtitles_satisfy(
+    release: &Value,
+    requirements: &LanguageRequirements,
+    policy: ServarrLanguageCandidatePolicy,
+) -> bool {
     if requirements.subtitles.is_empty() {
         return true;
     }
-
-    // Sonarr/Radarr release resources do not reliably expose subtitle-track
-    // language availability. Only accept a candidate if a future API/provider
-    // includes explicit subtitle language fields we can normalize.
     let subtitle_langs = release_subtitle_languages(release);
-    !subtitle_langs.is_empty()
+    if !subtitle_langs.is_empty()
         && requirements
             .subtitles
             .iter()
             .all(|lang| subtitle_langs.contains(lang))
+    {
+        return true;
+    }
+    match policy {
+        ServarrLanguageCandidatePolicy::Strict => false,
+        ServarrLanguageCandidatePolicy::CustomFormat => custom_formats_indicate_subtitles(release),
+        ServarrLanguageCandidatePolicy::CustomFormatOrTitle => {
+            custom_formats_indicate_subtitles(release) || title_indicates_subtitles(release, false)
+        }
+        ServarrLanguageCandidatePolicy::TitleGuess => {
+            custom_formats_indicate_subtitles(release) || title_indicates_subtitles(release, true)
+        }
+    }
 }
 
 fn release_languages(release: &Value) -> BTreeSet<String> {
@@ -286,6 +362,135 @@ fn release_subtitle_languages(release: &Value) -> BTreeSet<String> {
         collect_language_values(release.get(key), &mut out);
     }
     out
+}
+
+fn custom_formats(release: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(items) = release.get("customFormats").and_then(Value::as_array) {
+        for item in items {
+            if let Some(name) = item.get("name").and_then(Value::as_str) {
+                out.push(name.to_ascii_lowercase());
+            } else if let Some(name) = item.as_str() {
+                out.push(name.to_ascii_lowercase());
+            }
+        }
+    }
+    out
+}
+
+fn release_title_lower(release: &Value) -> String {
+    release_title(release)
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .replace(['.', '_', '-'], " ")
+}
+
+fn custom_formats_indicate_audio(release: &Value, required_audio: &[String]) -> bool {
+    let formats = custom_formats(release);
+    if formats
+        .iter()
+        .any(|f| f.contains("multi") && (f.contains("audio") || f.contains("dub")))
+    {
+        return true;
+    }
+    if required_audio.iter().any(|l| l == "eng")
+        && formats
+            .iter()
+            .any(|f| f.contains("dub") || f.contains("eng"))
+    {
+        return true;
+    }
+    false
+}
+
+fn custom_formats_indicate_subtitles(release: &Value) -> bool {
+    custom_formats(release)
+        .iter()
+        .any(|f| f.contains("sub") || f.contains("msub"))
+}
+
+fn title_indicates_audio(release: &Value, required_audio: &[String], loose: bool) -> bool {
+    let title = release_title_lower(release);
+    if title.contains("dual audio") || title.contains("multi audio") || title.contains("multi dub")
+    {
+        return true;
+    }
+    if required_audio.iter().any(|l| l == "eng")
+        && (title.contains("english dub") || title.contains("eng dub"))
+    {
+        return true;
+    }
+    if loose {
+        return required_audio.iter().any(|lang| match lang.as_str() {
+            "eng" => title.contains("eng") || title.contains("dub"),
+            "jpn" => title.contains("jpn") || title.contains("jap") || title.contains("japanese"),
+            "spa" => title.contains("spa") || title.contains("spanish"),
+            "fra" => title.contains("fre") || title.contains("fra") || title.contains("french"),
+            _ => title.contains(lang),
+        });
+    }
+    false
+}
+
+fn title_indicates_subtitles(release: &Value, loose: bool) -> bool {
+    let title = release_title_lower(release);
+    title.contains("multi subs")
+        || title.contains("multi sub")
+        || title.contains("msubs")
+        || title.contains("multi subtitles")
+        || (loose && (title.contains("sub") || title.contains("subs")))
+}
+
+fn release_match_evidence(
+    release: &Value,
+    requirements: &LanguageRequirements,
+    policy: ServarrLanguageCandidatePolicy,
+) -> String {
+    let mut parts = Vec::new();
+    let langs = release_languages(release);
+    if !langs.is_empty() {
+        parts.push(format!(
+            "release languages [{}]",
+            langs.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+    }
+    let subtitle_langs = release_subtitle_languages(release);
+    if !subtitle_langs.is_empty() {
+        parts.push(format!(
+            "subtitle languages [{}]",
+            subtitle_langs.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+    }
+    let formats = custom_formats(release);
+    if !formats.is_empty() {
+        parts.push(format!("custom formats [{}]", formats.join(", ")));
+    }
+    if policy != ServarrLanguageCandidatePolicy::Strict {
+        if custom_formats_indicate_audio(release, &requirements.audio) {
+            parts.push("custom-format audio hint".to_string());
+        }
+        if custom_formats_indicate_subtitles(release) {
+            parts.push("custom-format subtitle hint".to_string());
+        }
+        if title_indicates_audio(
+            release,
+            &requirements.audio,
+            policy == ServarrLanguageCandidatePolicy::TitleGuess,
+        ) {
+            parts.push("title audio hint".to_string());
+        }
+        if title_indicates_subtitles(
+            release,
+            policy == ServarrLanguageCandidatePolicy::TitleGuess,
+        ) {
+            parts.push("title subtitle hint".to_string());
+        }
+    }
+    if parts.is_empty() {
+        "no language evidence".to_string()
+    } else {
+        parts.join("; ")
+    }
 }
 
 fn collect_language_values(value: Option<&Value>, out: &mut BTreeSet<String>) {
@@ -494,6 +699,7 @@ mod tests {
                 audio: vec!["eng".to_string()],
                 subtitles: Vec::new(),
             },
+            RedownloadOptions::default(),
         )
         .unwrap();
 
@@ -543,6 +749,7 @@ mod tests {
                 audio: vec!["eng".to_string()],
                 subtitles: Vec::new(),
             },
+            RedownloadOptions::default(),
         )
         .unwrap();
 
@@ -589,6 +796,7 @@ mod tests {
                 audio: vec!["eng".to_string()],
                 subtitles: Vec::new(),
             },
+            RedownloadOptions::default(),
         )
         .unwrap_err();
 
@@ -598,6 +806,94 @@ mod tests {
         search.assert();
 
         env::remove_var("sonarr_episode_id");
+    }
+
+    #[test]
+    fn dry_run_does_not_grab_or_blocklist() {
+        let _guard = env_lock();
+        env::set_var("sonarr_episode_id", "77");
+        env::set_var("DIRECT_PLAY_NICE_SONARR_HISTORY_ID", "1234");
+
+        let mut server = mockito::Server::new();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "77".into()))
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "title":"dry run candidate",
+                    "rejected": false,
+                    "languages":[{"name":"English"}]
+                }])
+                .to_string(),
+            )
+            .create();
+
+        let outcome = trigger_verified_redownload(
+            IntegrationKind::Sonarr,
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string()],
+                subtitles: Vec::new(),
+            },
+            RedownloadOptions {
+                dry_run: true,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, RedownloadOutcome::DryRun { .. }));
+        search.assert();
+
+        env::remove_var("sonarr_episode_id");
+        env::remove_var("DIRECT_PLAY_NICE_SONARR_HISTORY_ID");
+    }
+
+    #[test]
+    fn custom_format_policy_accepts_multi_audio_and_multi_sub_hints() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string(), "jpn".to_string()],
+            subtitles: vec!["eng".to_string()],
+        };
+        let releases = vec![json!({
+            "title":"candidate",
+            "rejected": false,
+            "customFormats":[{"name":"Anime-multi-audio"}, {"name":"anime-multi-sub"}],
+            "customFormatScore": 600
+        })];
+
+        assert!(select_verified_release(
+            &releases,
+            &req,
+            ServarrLanguageCandidatePolicy::CustomFormat
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn title_policy_accepts_dual_audio_multi_sub_tokens() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string(), "jpn".to_string()],
+            subtitles: vec!["eng".to_string()],
+        };
+        let releases = vec![json!({
+            "title":"Show S01E01 1080p Dual-Audio Multi-Subs",
+            "rejected": false
+        })];
+
+        assert!(select_verified_release(
+            &releases,
+            &req,
+            ServarrLanguageCandidatePolicy::CustomFormatOrTitle
+        )
+        .is_some());
     }
 
     #[test]
@@ -613,7 +909,9 @@ mod tests {
             json!({"title":"good", "rejected": false, "languages":[{"name":"English"}], "customFormatScore": 10}),
         ];
 
-        let selected = select_verified_release(&releases, &req).unwrap();
+        let selected =
+            select_verified_release(&releases, &req, ServarrLanguageCandidatePolicy::Strict)
+                .unwrap();
         assert_eq!(release_title(selected).as_deref(), Some("good"));
     }
 
@@ -625,7 +923,10 @@ mod tests {
             subtitles: vec!["spa".to_string()],
         };
         let releases = vec![json!({"title":"ambiguous", "languages":[{"name":"English"}]})];
-        assert!(select_verified_release(&releases, &req).is_none());
+        assert!(
+            select_verified_release(&releases, &req, ServarrLanguageCandidatePolicy::Strict)
+                .is_none()
+        );
     }
 
     #[test]
@@ -640,6 +941,9 @@ mod tests {
             "languages":[{"name":"English"}],
             "subtitleLanguages":[{"name":"Spanish"}]
         })];
-        assert!(select_verified_release(&releases, &req).is_some());
+        assert!(
+            select_verified_release(&releases, &req, ServarrLanguageCandidatePolicy::Strict)
+                .is_some()
+        );
     }
 }

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -212,8 +212,9 @@ pub fn run_radarr_language_audit(
     audit_options: AuditOptions,
 ) -> Result<AuditSummary> {
     let client = ApiClient::from_settings(IntegrationKind::Radarr, settings)?;
+    let mut summary =
+        client.radarr_force_import_pending_language_upgrades(requirements, redownload_options)?;
     let records = client.radarr_recent_import_history(audit_options.lookback_days)?;
-    let mut summary = AuditSummary::default();
     let mut searched = 0usize;
 
     for record in records {
@@ -587,6 +588,144 @@ impl ApiClient {
         self.get(&format!("{}/api/v3/moviefile/{}", self.base_url, file_id))
     }
 
+    fn radarr_force_import_pending_language_upgrades(
+        &self,
+        requirements: &LanguageRequirements,
+        options: RedownloadOptions,
+    ) -> Result<AuditSummary> {
+        let mut summary = AuditSummary::default();
+        let response = self.get(&format!(
+            "{}/api/v3/queue?page=1&pageSize=100&includeMovie=true",
+            self.base_url
+        ))?;
+        let records = response
+            .get("records")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        for queue_item in records {
+            let state = queue_item
+                .get("trackedDownloadState")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let status = queue_item
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if state != "importPending" || status != "completed" {
+                continue;
+            }
+            let Some(movie_id) = queue_item
+                .get("movieId")
+                .and_then(Value::as_i64)
+                .or_else(|| {
+                    queue_item
+                        .get("movie")
+                        .and_then(|m| m.get("id"))
+                        .and_then(Value::as_i64)
+                })
+            else {
+                continue;
+            };
+            let Some(download_id) = queue_item.get("downloadId").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(current_file_id) = queue_item
+                .get("movie")
+                .and_then(|m| m.get("movieFileId"))
+                .and_then(Value::as_i64)
+            else {
+                continue;
+            };
+            let Some(current_file) = queue_item.get("movie").and_then(|m| m.get("movieFile"))
+            else {
+                continue;
+            };
+            let current_report = language_report_from_episode_file(current_file, requirements);
+            if current_report.satisfied() {
+                continue;
+            }
+            let manual_items = self.radarr_manual_import_items(download_id, movie_id)?;
+            let Some(item) = manual_items.into_iter().find(|item| {
+                manual_import_item_satisfies(
+                    item,
+                    &queue_item,
+                    requirements,
+                    options.candidate_policy,
+                )
+            }) else {
+                continue;
+            };
+            summary.missing += 1;
+            summary.searched += 1;
+            let title = queue_item
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("<pending import>");
+            if options.dry_run {
+                summary.dry_run += 1;
+                info!(
+                    "Radarr language audit dry-run: would force-import pending movie {} from '{}'.",
+                    movie_id, title
+                );
+                continue;
+            }
+            self.radarr_delete_movie_file(current_file_id)?;
+            self.radarr_post_manual_import(item, movie_id)?;
+            if let Some(queue_id) = queue_item.get("id").and_then(Value::as_i64) {
+                if let Err(err) = self.radarr_delete_queue_item(queue_id) {
+                    warn!(
+                        "Radarr language audit force-imported movie {} but could not remove completed queue item {}: {}",
+                        movie_id, queue_id, err
+                    );
+                }
+            }
+            summary.grabbed += 1;
+            info!(
+                "Radarr language audit force-imported pending language upgrade for movie {} from '{}'.",
+                movie_id, title
+            );
+        }
+        Ok(summary)
+    }
+
+    fn radarr_manual_import_items(&self, download_id: &str, movie_id: i64) -> Result<Vec<Value>> {
+        let endpoint = format!(
+            "{}/api/v3/manualimport?downloadId={}&movieId={}&filterExistingFiles=false",
+            self.base_url,
+            url_encode(download_id),
+            movie_id
+        );
+        self.get(&endpoint)?
+            .as_array()
+            .cloned()
+            .ok_or_else(|| anyhow!("Radarr manual import did not return an array"))
+    }
+
+    fn radarr_post_manual_import(&self, mut item: Value, movie_id: i64) -> Result<()> {
+        if let Value::Object(ref mut map) = item {
+            map.insert("movieId".to_string(), Value::from(movie_id));
+        }
+        let endpoint = format!("{}/api/v3/manualimport", self.base_url);
+        self.post_json(&endpoint, &Value::Array(vec![item]))?;
+        Ok(())
+    }
+
+    fn radarr_delete_movie_file(&self, file_id: i64) -> Result<()> {
+        let endpoint = format!("{}/api/v3/moviefile/{}", self.base_url, file_id);
+        self.delete(&endpoint)?;
+        Ok(())
+    }
+
+    fn radarr_delete_queue_item(&self, queue_id: i64) -> Result<()> {
+        let endpoint = format!(
+            "{}/api/v3/queue/{}?removeFromClient=false&blocklist=false",
+            self.base_url, queue_id
+        );
+        self.delete(&endpoint)?;
+        Ok(())
+    }
+
     fn grab_release(&self, release: &Value) -> Result<()> {
         let endpoint = format!("{}/api/v3/release", self.base_url);
         self.post_json(&endpoint, release)
@@ -655,6 +794,16 @@ impl ApiClient {
         .with_context(|| format!("POST {}", endpoint))?;
         read_json_response(response)
     }
+
+    fn delete(&self, endpoint: &str) -> Result<Value> {
+        let response = self
+            .agent
+            .delete(endpoint)
+            .set("X-Api-Key", &self.api_key)
+            .call()
+            .with_context(|| format!("DELETE {}", endpoint))?;
+        read_json_response(response)
+    }
 }
 
 fn read_json_response(response: ureq::Response) -> Result<Value> {
@@ -674,6 +823,23 @@ fn history_episode_id(record: &Value) -> Option<i64> {
         .and_then(|episode| episode.get("id"))
         .and_then(Value::as_i64)
         .or_else(|| record.get("episodeId").and_then(Value::as_i64))
+}
+
+fn manual_import_item_satisfies(
+    item: &Value,
+    queue_item: &Value,
+    requirements: &LanguageRequirements,
+    policy: ServarrLanguageCandidatePolicy,
+) -> bool {
+    let title = queue_item
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let mut candidate = item.clone();
+    if let Value::Object(ref mut map) = candidate {
+        map.insert("title".to_string(), Value::from(title));
+    }
+    release_satisfies_languages(&candidate, requirements, policy)
 }
 
 fn language_report_from_episode_file(

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -70,6 +70,23 @@ pub enum RedownloadOutcome {
     NoVerifiedRelease { reason: String },
 }
 
+pub fn run_language_audit(
+    kind: IntegrationKind,
+    settings: &ApiSettings,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    audit_options: AuditOptions,
+) -> Result<AuditSummary> {
+    match kind {
+        IntegrationKind::Sonarr => {
+            run_sonarr_language_audit(settings, requirements, redownload_options, audit_options)
+        }
+        IntegrationKind::Radarr => {
+            run_radarr_language_audit(settings, requirements, redownload_options, audit_options)
+        }
+    }
+}
+
 pub fn run_sonarr_language_audit(
     settings: &ApiSettings,
     requirements: &LanguageRequirements,
@@ -177,6 +194,124 @@ pub fn run_sonarr_language_audit(
 
     info!(
         "Sonarr language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, errors={}",
+        summary.checked,
+        summary.missing,
+        summary.searched,
+        summary.dry_run,
+        summary.grabbed,
+        summary.no_candidate,
+        summary.errors
+    );
+    Ok(summary)
+}
+
+pub fn run_radarr_language_audit(
+    settings: &ApiSettings,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    audit_options: AuditOptions,
+) -> Result<AuditSummary> {
+    let client = ApiClient::from_settings(IntegrationKind::Radarr, settings)?;
+    let records = client.radarr_recent_import_history(audit_options.lookback_days)?;
+    let mut summary = AuditSummary::default();
+    let mut searched = 0usize;
+
+    for record in records {
+        let Some(movie_id) = record.get("movieId").and_then(Value::as_i64) else {
+            continue;
+        };
+        let Some(history_id) = record.get("id").and_then(Value::as_i64) else {
+            continue;
+        };
+        let movie = match client.radarr_movie(movie_id) {
+            Ok(movie) => movie,
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Radarr language audit could not fetch movie {}: {}",
+                    movie_id, err
+                );
+                continue;
+            }
+        };
+        let Some(file_id) = movie.get("movieFileId").and_then(Value::as_i64) else {
+            continue;
+        };
+        let movie_file = match client.radarr_movie_file(file_id) {
+            Ok(file) => file,
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Radarr language audit could not fetch movie file {}: {}",
+                    file_id, err
+                );
+                continue;
+            }
+        };
+        summary.checked += 1;
+        let report = language_report_from_episode_file(&movie_file, requirements);
+        let path = movie_file
+            .get("path")
+            .and_then(Value::as_str)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(format!("radarr:moviefile:{file_id}")));
+        if let Err(err) =
+            cache::record_assessment(IntegrationKind::Radarr, &path, requirements, &report)
+        {
+            warn!(
+                "Radarr language audit failed to update DPN cache for '{}': {}",
+                path.display(),
+                err
+            );
+        }
+        if report.satisfied() {
+            continue;
+        }
+        summary.missing += 1;
+        if searched >= audit_options.max_searches {
+            continue;
+        }
+        searched += 1;
+        summary.searched += 1;
+        match client.redownload_for_target(
+            Target::RadarrMovie { movie_id },
+            history_id,
+            requirements,
+            redownload_options,
+        ) {
+            Ok(RedownloadOutcome::Grabbed { title }) => {
+                summary.grabbed += 1;
+                info!(
+                    "Radarr language audit grabbed replacement for movie {}: {}",
+                    movie_id, title
+                );
+            }
+            Ok(RedownloadOutcome::DryRun { summary: details }) => {
+                summary.dry_run += 1;
+                info!(
+                    "Radarr language audit dry-run for movie {}: {}",
+                    movie_id, details
+                );
+            }
+            Ok(RedownloadOutcome::NoVerifiedRelease { reason }) => {
+                summary.no_candidate += 1;
+                info!(
+                    "Radarr language audit found no replacement for movie {}: {}",
+                    movie_id, reason
+                );
+            }
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Radarr language audit replacement check failed for movie {}: {}",
+                    movie_id, err
+                );
+            }
+        }
+    }
+
+    info!(
+        "Radarr language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, errors={}",
         summary.checked,
         summary.missing,
         summary.searched,
@@ -401,6 +536,55 @@ impl ApiClient {
 
     fn sonarr_episode_file(&self, file_id: i64) -> Result<Value> {
         self.get(&format!("{}/api/v3/episodefile/{}", self.base_url, file_id))
+    }
+
+    fn radarr_recent_import_history(&self, lookback_days: u32) -> Result<Vec<Value>> {
+        let mut out = Vec::new();
+        let min_day = current_day_number().saturating_sub(lookback_days as i64);
+        for page in 1..=10 {
+            let endpoint = format!(
+                "{}/api/v3/history?page={page}&pageSize=100&sortKey=date&sortDirection=descending&includeMovie=true",
+                self.base_url
+            );
+            let response = self.get(&endpoint)?;
+            let records = response
+                .get("records")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if records.is_empty() {
+                break;
+            }
+            let mut saw_old = false;
+            for record in records {
+                if let Some(day) = record
+                    .get("date")
+                    .and_then(Value::as_str)
+                    .and_then(iso_day_number)
+                {
+                    if day < min_day {
+                        saw_old = true;
+                        continue;
+                    }
+                }
+                if record.get("eventType").and_then(Value::as_str) == Some("downloadFolderImported")
+                {
+                    out.push(record);
+                }
+            }
+            if saw_old {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    fn radarr_movie(&self, movie_id: i64) -> Result<Value> {
+        self.get(&format!("{}/api/v3/movie/{}", self.base_url, movie_id))
+    }
+
+    fn radarr_movie_file(&self, file_id: i64) -> Result<Value> {
+        self.get(&format!("{}/api/v3/moviefile/{}", self.base_url, file_id))
     }
 
     fn grab_release(&self, release: &Value) -> Result<()> {

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -7,7 +7,7 @@ use super::language::{
     LanguageRequirements,
 };
 use super::IntegrationKind;
-use crate::ServarrLanguageCandidatePolicy;
+use crate::{ServarrLanguageAuditScope, ServarrLanguageCandidatePolicy};
 use anyhow::{anyhow, bail, Context, Result};
 use log::{info, warn};
 use serde_json::Value;
@@ -39,6 +39,7 @@ impl Default for RedownloadOptions {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuditOptions {
+    pub scope: ServarrLanguageAuditScope,
     pub lookback_days: u32,
     pub max_searches: usize,
 }
@@ -46,6 +47,7 @@ pub struct AuditOptions {
 impl Default for AuditOptions {
     fn default() -> Self {
         Self {
+            scope: ServarrLanguageAuditScope::History,
             lookback_days: 30,
             max_searches: 20,
         }
@@ -94,6 +96,30 @@ pub fn run_sonarr_language_audit(
     audit_options: AuditOptions,
 ) -> Result<AuditSummary> {
     let client = ApiClient::from_settings(IntegrationKind::Sonarr, settings)?;
+    let summary = match audit_options.scope {
+        ServarrLanguageAuditScope::History => run_sonarr_history_language_audit(
+            &client,
+            requirements,
+            redownload_options,
+            audit_options,
+        )?,
+        ServarrLanguageAuditScope::Inventory => run_sonarr_inventory_language_audit(
+            &client,
+            requirements,
+            redownload_options,
+            audit_options,
+        )?,
+    };
+    log_audit_summary("Sonarr", &summary);
+    Ok(summary)
+}
+
+fn run_sonarr_history_language_audit(
+    client: &ApiClient,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    audit_options: AuditOptions,
+) -> Result<AuditSummary> {
     let records = client.sonarr_recent_import_history(audit_options.lookback_days)?;
     let mut summary = AuditSummary::default();
     let mut searched = 0usize;
@@ -109,35 +135,123 @@ pub fn run_sonarr_language_audit(
         else {
             continue;
         };
-        summary.checked += 1;
-        let report = language_report_from_episode_file(&episode_file, requirements);
-        record_language_audit_assessment(
-            IntegrationKind::Sonarr,
-            "sonarr:episodefile",
-            &episode_file,
-            requirements,
-            &report,
-        );
-        if report.satisfied() {
-            continue;
-        }
-        summary.missing += 1;
-        if searched >= audit_options.max_searches {
-            continue;
-        }
-        searched += 1;
-        summary.searched += 1;
-        client.apply_audit_redownload_outcome(
-            Target::SonarrEpisode { episode_id },
-            history_id,
+        process_sonarr_language_audit_item(
+            client,
+            episode_id,
+            Some(history_id),
+            episode_file,
             requirements,
             redownload_options,
+            audit_options.max_searches,
+            &mut searched,
             &mut summary,
         );
     }
 
-    log_audit_summary("Sonarr", &summary);
     Ok(summary)
+}
+
+fn run_sonarr_inventory_language_audit(
+    client: &ApiClient,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    audit_options: AuditOptions,
+) -> Result<AuditSummary> {
+    let items = client.sonarr_inventory_episode_files()?;
+    let mut summary = AuditSummary::default();
+    let mut searched = 0usize;
+
+    for (episode_id, episode_file) in items {
+        if searched >= audit_options.max_searches {
+            break;
+        }
+        process_sonarr_language_audit_item(
+            client,
+            episode_id,
+            None,
+            episode_file,
+            requirements,
+            redownload_options,
+            audit_options.max_searches,
+            &mut searched,
+            &mut summary,
+        );
+    }
+
+    Ok(summary)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_sonarr_language_audit_item(
+    client: &ApiClient,
+    episode_id: i64,
+    history_id: Option<i64>,
+    episode_file: Value,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    max_searches: usize,
+    searched: &mut usize,
+    summary: &mut AuditSummary,
+) {
+    summary.checked += 1;
+    let report = language_report_from_episode_file(&episode_file, requirements);
+    record_language_audit_assessment(
+        IntegrationKind::Sonarr,
+        "sonarr:episodefile",
+        &episode_file,
+        requirements,
+        &report,
+    );
+    if report.satisfied() {
+        return;
+    }
+    summary.missing += 1;
+    if *searched >= max_searches {
+        return;
+    }
+    *searched += 1;
+    summary.searched += 1;
+
+    let history_id = match history_id {
+        Some(id) => Some(id),
+        None => match client.sonarr_latest_import_history_id(episode_id) {
+            Ok(id) => id,
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr inventory language audit could not fetch import history for episode {}: {}",
+                    episode_id, err
+                );
+                return;
+            }
+        },
+    };
+    let Some(history_id) = history_id else {
+        if redownload_options.dry_run {
+            client.apply_audit_redownload_outcome(
+                Target::SonarrEpisode { episode_id },
+                0,
+                requirements,
+                redownload_options,
+                summary,
+            );
+        } else {
+            summary.errors += 1;
+            warn!(
+                "Sonarr inventory language audit could not identify import history for episode {}; refusing to grab replacement.",
+                episode_id
+            );
+        }
+        return;
+    };
+
+    client.apply_audit_redownload_outcome(
+        Target::SonarrEpisode { episode_id },
+        history_id,
+        requirements,
+        redownload_options,
+        summary,
+    );
 }
 
 pub fn run_radarr_language_audit(
@@ -398,6 +512,71 @@ impl ApiClient {
             }
         }
         Ok(out)
+    }
+
+    fn sonarr_inventory_episode_files(&self) -> Result<Vec<(i64, Value)>> {
+        let series = self
+            .get(&format!("{}/api/v3/series", self.base_url))?
+            .as_array()
+            .cloned()
+            .ok_or_else(|| anyhow!("Sonarr series endpoint did not return an array"))?;
+        let mut out = Vec::new();
+        for item in series {
+            let Some(series_id) = item.get("id").and_then(Value::as_i64) else {
+                continue;
+            };
+            let endpoint = format!(
+                "{}/api/v3/episode?seriesId={}&includeEpisodeFile=true",
+                self.base_url, series_id
+            );
+            let episodes = self
+                .get(&endpoint)?
+                .as_array()
+                .cloned()
+                .ok_or_else(|| anyhow!("Sonarr episode endpoint did not return an array"))?;
+            for episode in episodes {
+                if episode.get("hasFile").and_then(Value::as_bool) == Some(false) {
+                    continue;
+                }
+                let Some(episode_id) = episode.get("id").and_then(Value::as_i64) else {
+                    continue;
+                };
+                let Some(file_id) = episode.get("episodeFileId").and_then(Value::as_i64) else {
+                    continue;
+                };
+                if let Some(file) = episode.get("episodeFile").filter(|file| file.is_object()) {
+                    out.push((episode_id, file.clone()));
+                    continue;
+                }
+                match self.sonarr_episode_file(file_id) {
+                    Ok(file) => out.push((episode_id, file)),
+                    Err(err) => warn!(
+                        "Sonarr inventory language audit could not fetch episode file {} for episode {}: {}",
+                        file_id, episode_id, err
+                    ),
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn sonarr_latest_import_history_id(&self, episode_id: i64) -> Result<Option<i64>> {
+        let endpoint = format!(
+            "{}/api/v3/history?page=1&pageSize=20&sortKey=date&sortDirection=descending&episodeId={}",
+            self.base_url, episode_id
+        );
+        let response = self.get(&endpoint)?;
+        let records = response
+            .get("records")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        Ok(records
+            .iter()
+            .find(|record| {
+                record.get("eventType").and_then(Value::as_str) == Some("downloadFolderImported")
+            })
+            .and_then(|record| record.get("id").and_then(Value::as_i64)))
     }
 
     fn sonarr_current_episode_file(
@@ -1376,6 +1555,91 @@ mod tests {
             vec![10, 11, 12, 13, 14]
         );
         env::remove_var("sonarr_episodefile_episodeids");
+    }
+
+    #[test]
+    fn sonarr_inventory_audit_dry_run_searches_current_episode_files() {
+        let mut server = mockito::Server::new();
+        let series = server
+            .mock("GET", "/api/v3/series")
+            .with_status(200)
+            .with_body(json!([{ "id": 1, "title": "Example" }]).to_string())
+            .create();
+        let episodes = server
+            .mock("GET", "/api/v3/episode")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "id": 77,
+                    "seriesId": 1,
+                    "hasFile": true,
+                    "episodeFileId": 555,
+                    "episodeFile": {
+                        "id": 555,
+                        "path": "/media/example.mkv",
+                        "mediaInfo": {
+                            "audioLanguages": "jpn",
+                            "subtitles": "eng"
+                        }
+                    }
+                }])
+                .to_string(),
+            )
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "77".into()))
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "title":"example S01E01 1080p Dual-Audio Multi-Subs",
+                    "rejected": true,
+                    "downloadAllowed": true,
+                    "rejections":["Existing file meets cutoff: Unknown"],
+                    "customFormatScore": 875
+                }])
+                .to_string(),
+            )
+            .create();
+
+        let summary = run_sonarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string(), "jpn".to_string()],
+                subtitles: vec!["eng".to_string()],
+            },
+            RedownloadOptions {
+                dry_run: true,
+                candidate_policy: ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::Inventory,
+                lookback_days: 30,
+                max_searches: 10,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.dry_run, 1);
+        assert_eq!(summary.errors, 0);
+        series.assert();
+        episodes.assert();
+        history.assert();
+        search.assert();
     }
 
     #[test]

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -8,6 +8,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use log::{info, warn};
 use serde_json::Value;
 use std::collections::BTreeSet;
+use std::time::Duration;
+use ureq::{Agent, AgentBuilder};
 
 #[derive(Debug, Clone, Default)]
 pub struct ApiSettings {
@@ -95,6 +97,7 @@ struct ApiClient {
     kind: IntegrationKind,
     base_url: String,
     api_key: String,
+    agent: Agent,
 }
 
 impl ApiClient {
@@ -124,6 +127,11 @@ impl ApiClient {
             kind,
             base_url: base_url.trim_end_matches('/').to_string(),
             api_key,
+            agent: AgentBuilder::new()
+                .timeout_read(Duration::from_secs(30 * 60))
+                .timeout_write(Duration::from_secs(5 * 60))
+                .timeout_connect(Duration::from_secs(60))
+                .build(),
         })
     }
 
@@ -192,7 +200,9 @@ impl ApiClient {
     }
 
     fn get(&self, endpoint: &str) -> Result<Value> {
-        let response = ureq::get(endpoint)
+        let response = self
+            .agent
+            .get(endpoint)
             .set("X-Api-Key", &self.api_key)
             .call()
             .with_context(|| format!("GET {}", endpoint))?;
@@ -200,7 +210,9 @@ impl ApiClient {
     }
 
     fn post_json(&self, endpoint: &str, body: &Value) -> Result<Value> {
-        let request = ureq::post(endpoint)
+        let request = self
+            .agent
+            .post(endpoint)
             .set("X-Api-Key", &self.api_key)
             .set("Content-Type", "application/json");
         let response = if body.is_null() {

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -1670,6 +1670,585 @@ mod tests {
     }
 
     #[test]
+    fn sonarr_inventory_audit_grabs_replacement_and_blocklists_latest_history() {
+        let mut server = mockito::Server::new();
+        let series = server
+            .mock("GET", "/api/v3/series")
+            .with_status(200)
+            .with_body(json!([{ "id": 1, "title": "Example" }]).to_string())
+            .create();
+        let episodes = server
+            .mock("GET", "/api/v3/episode")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "id": 77,
+                    "seriesId": 1,
+                    "hasFile": true,
+                    "episodeFileId": 555,
+                    "episodeFile": {
+                        "id": 555,
+                        "path": "/media/example.mkv",
+                        "mediaInfo": { "audioLanguages": "jpn", "subtitles": "eng" }
+                    }
+                }])
+                .to_string(),
+            )
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(
+                json!({
+                    "records": [{
+                        "id": 1234,
+                        "eventType": "downloadFolderImported",
+                        "episodeId": 77
+                    }]
+                })
+                .to_string(),
+            )
+            .create();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "77".into()))
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "title": "target replacement",
+                    "rejected": false,
+                    "languages": [{"name":"English"}, {"name":"Japanese"}],
+                    "subtitleLanguages": [{"name":"English"}]
+                }])
+                .to_string(),
+            )
+            .create();
+        let grab = server
+            .mock("POST", "/api/v3/release")
+            .match_header("x-api-key", "test-key")
+            .with_status(200)
+            .with_body("{}")
+            .create();
+        let blocklist = server
+            .mock("POST", "/api/v3/history/failed/1234")
+            .match_header("x-api-key", "test-key")
+            .with_status(200)
+            .with_body("{}")
+            .create();
+
+        let summary = run_sonarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string(), "jpn".to_string()],
+                subtitles: vec!["eng".to_string()],
+            },
+            RedownloadOptions {
+                dry_run: false,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::Inventory,
+                lookback_days: 30,
+                max_searches: 10,
+                episode_ids: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.grabbed, 1);
+        assert_eq!(summary.errors, 0);
+        series.assert();
+        episodes.assert();
+        history.assert();
+        search.assert();
+        grab.assert();
+        blocklist.assert();
+    }
+
+    #[test]
+    fn sonarr_inventory_audit_stops_after_max_searches() {
+        let mut server = mockito::Server::new();
+        let series = server
+            .mock("GET", "/api/v3/series")
+            .with_status(200)
+            .with_body(json!([{ "id": 1, "title": "Example" }]).to_string())
+            .create();
+        let episodes = server
+            .mock("GET", "/api/v3/episode")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(
+                json!([
+                    {
+                        "id": 77,
+                        "seriesId": 1,
+                        "hasFile": true,
+                        "episodeFileId": 555,
+                        "episodeFile": {
+                            "id": 555,
+                            "path": "/media/one.mkv",
+                            "mediaInfo": { "audioLanguages": "jpn", "subtitles": "eng" }
+                        }
+                    },
+                    {
+                        "id": 78,
+                        "seriesId": 1,
+                        "hasFile": true,
+                        "episodeFileId": 556,
+                        "episodeFile": {
+                            "id": 556,
+                            "path": "/media/two.mkv",
+                            "mediaInfo": { "audioLanguages": "jpn", "subtitles": "eng" }
+                        }
+                    }
+                ])
+                .to_string(),
+            )
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "77".into()))
+            .with_status(200)
+            .with_body(json!([]).to_string())
+            .create();
+
+        let summary = run_sonarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string(), "jpn".to_string()],
+                subtitles: vec!["eng".to_string()],
+            },
+            RedownloadOptions {
+                dry_run: true,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::Inventory,
+                lookback_days: 30,
+                max_searches: 1,
+                episode_ids: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.no_candidate, 1);
+        series.assert();
+        episodes.assert();
+        history.assert();
+        search.assert();
+    }
+
+    #[test]
+    fn sonarr_inventory_audit_targeted_episode_ids_skip_series_scan() {
+        let mut server = mockito::Server::new();
+        let episode = server
+            .mock("GET", "/api/v3/episode/77")
+            .with_status(200)
+            .with_body(json!({ "id": 77, "episodeFileId": 555 }).to_string())
+            .create();
+        let episode_file = server
+            .mock("GET", "/api/v3/episodefile/555")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "id": 555,
+                    "path": "/media/example.mkv",
+                    "mediaInfo": { "audioLanguages": "jpn", "subtitles": "eng" }
+                })
+                .to_string(),
+            )
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "77".into()))
+            .with_status(200)
+            .with_body(
+                json!([{ "title": "target Dual-Audio Multi-Subs", "rejected": false }]).to_string(),
+            )
+            .create();
+
+        let summary = run_sonarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string(), "jpn".to_string()],
+                subtitles: vec!["eng".to_string()],
+            },
+            RedownloadOptions {
+                dry_run: true,
+                candidate_policy: ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::Inventory,
+                lookback_days: 30,
+                max_searches: 10,
+                episode_ids: vec![77],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.dry_run, 1);
+        episode.assert();
+        episode_file.assert();
+        history.assert();
+        search.assert();
+    }
+
+    #[test]
+    fn sonarr_inventory_apply_refuses_without_import_history() {
+        let mut server = mockito::Server::new();
+        let episode = server
+            .mock("GET", "/api/v3/episode/77")
+            .with_status(200)
+            .with_body(json!({ "id": 77, "episodeFileId": 555 }).to_string())
+            .create();
+        let episode_file = server
+            .mock("GET", "/api/v3/episodefile/555")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "id": 555,
+                    "path": "/media/example.mkv",
+                    "mediaInfo": { "audioLanguages": "jpn", "subtitles": "eng" }
+                })
+                .to_string(),
+            )
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+
+        let summary = run_sonarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string(), "jpn".to_string()],
+                subtitles: vec!["eng".to_string()],
+            },
+            RedownloadOptions {
+                dry_run: false,
+                candidate_policy: ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::Inventory,
+                lookback_days: 30,
+                max_searches: 10,
+                episode_ids: vec![77],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.errors, 1);
+        assert_eq!(summary.grabbed, 0);
+        episode.assert();
+        episode_file.assert();
+        history.assert();
+    }
+
+    fn radarr_pending_queue_item() -> Value {
+        json!({
+            "id": 123,
+            "movieId": 88,
+            "downloadId": "download 1",
+            "title": "movie dual audio",
+            "status": "completed",
+            "trackedDownloadState": "importPending",
+            "movie": {
+                "id": 88,
+                "movieFileId": 999,
+                "movieFile": {
+                    "id": 999,
+                    "path": "/movies/current.mkv",
+                    "mediaInfo": { "audioLanguages": "jpn", "subtitles": "" }
+                }
+            }
+        })
+    }
+
+    fn radarr_requirements() -> LanguageRequirements {
+        LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string(), "jpn".to_string()],
+            subtitles: vec!["eng".to_string()],
+        }
+    }
+
+    #[test]
+    fn radarr_force_import_pending_language_upgrade_dry_run_is_safe() {
+        let mut server = mockito::Server::new();
+        let queue = server
+            .mock("GET", "/api/v3/queue")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [radarr_pending_queue_item()] }).to_string())
+            .create();
+        let manual = server
+            .mock("GET", "/api/v3/manualimport")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "path": "/downloads/movie.mkv",
+                    "languages": [{"name":"English"}, {"name":"Japanese"}],
+                    "subtitleLanguages": [{"name":"English"}]
+                }])
+                .to_string(),
+            )
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+
+        let summary = run_radarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &radarr_requirements(),
+            RedownloadOptions {
+                dry_run: true,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::History,
+                lookback_days: 30,
+                max_searches: 10,
+                episode_ids: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.dry_run, 1);
+        assert_eq!(summary.grabbed, 0);
+        queue.assert();
+        manual.assert();
+        history.assert();
+    }
+
+    #[test]
+    fn radarr_force_import_pending_language_upgrade_applies_manual_import() {
+        let mut server = mockito::Server::new();
+        let queue = server
+            .mock("GET", "/api/v3/queue")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [radarr_pending_queue_item()] }).to_string())
+            .create();
+        let manual = server
+            .mock("GET", "/api/v3/manualimport")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(
+                json!([{
+                    "path": "/downloads/movie.mkv",
+                    "languages": [{"name":"English"}, {"name":"Japanese"}],
+                    "subtitleLanguages": [{"name":"English"}]
+                }])
+                .to_string(),
+            )
+            .create();
+        let delete_file = server
+            .mock("DELETE", "/api/v3/moviefile/999")
+            .with_status(200)
+            .with_body("{}")
+            .create();
+        let post_import = server
+            .mock("POST", "/api/v3/manualimport")
+            .match_header("content-type", "application/json")
+            .with_status(200)
+            .with_body("{}")
+            .create();
+        let delete_queue = server
+            .mock("DELETE", "/api/v3/queue/123")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body("{}")
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+
+        let summary = run_radarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &radarr_requirements(),
+            RedownloadOptions {
+                dry_run: false,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::History,
+                lookback_days: 30,
+                max_searches: 10,
+                episode_ids: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.grabbed, 1);
+        assert_eq!(summary.errors, 0);
+        queue.assert();
+        manual.assert();
+        delete_file.assert();
+        post_import.assert();
+        delete_queue.assert();
+        history.assert();
+    }
+
+    #[test]
+    fn radarr_force_import_skips_when_current_movie_file_already_satisfies_requirements() {
+        let mut server = mockito::Server::new();
+        let mut queue_item = radarr_pending_queue_item();
+        queue_item["movie"]["movieFile"]["mediaInfo"] = json!({
+            "audioLanguages": "eng/jpn",
+            "subtitles": "eng"
+        });
+        let queue = server
+            .mock("GET", "/api/v3/queue")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [queue_item] }).to_string())
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+
+        let summary = run_radarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &radarr_requirements(),
+            RedownloadOptions {
+                dry_run: false,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::History,
+                lookback_days: 30,
+                max_searches: 10,
+                episode_ids: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.missing, 0);
+        assert_eq!(summary.searched, 0);
+        assert_eq!(summary.grabbed, 0);
+        assert_eq!(summary.errors, 0);
+        queue.assert();
+        history.assert();
+    }
+
+    #[test]
+    fn radarr_force_import_skips_when_manual_import_item_lacks_languages() {
+        let mut server = mockito::Server::new();
+        let queue = server
+            .mock("GET", "/api/v3/queue")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [radarr_pending_queue_item()] }).to_string())
+            .create();
+        let manual = server
+            .mock("GET", "/api/v3/manualimport")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!([{ "path": "/downloads/movie.mkv" }]).to_string())
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+
+        let summary = run_radarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &radarr_requirements(),
+            RedownloadOptions {
+                dry_run: false,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::History,
+                lookback_days: 30,
+                max_searches: 10,
+                episode_ids: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.missing, 0);
+        assert_eq!(summary.searched, 0);
+        assert_eq!(summary.grabbed, 0);
+        assert_eq!(summary.errors, 0);
+        queue.assert();
+        manual.assert();
+        history.assert();
+    }
+
+    #[test]
     fn sonarr_verified_redownload_grabs_specific_release_then_blocklists_old_history() {
         let _guard = env_lock();
         env::set_var("sonarr_episode_id", "77");

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -37,11 +37,12 @@ impl Default for RedownloadOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditOptions {
     pub scope: ServarrLanguageAuditScope,
     pub lookback_days: u32,
     pub max_searches: usize,
+    pub episode_ids: Vec<i64>,
 }
 
 impl Default for AuditOptions {
@@ -50,6 +51,7 @@ impl Default for AuditOptions {
             scope: ServarrLanguageAuditScope::History,
             lookback_days: 30,
             max_searches: 20,
+            episode_ids: Vec::new(),
         }
     }
 }
@@ -128,6 +130,10 @@ fn run_sonarr_history_language_audit(
         let Some(episode_id) = history_episode_id(&record) else {
             continue;
         };
+        if !audit_options.episode_ids.is_empty() && !audit_options.episode_ids.contains(&episode_id)
+        {
+            continue;
+        }
         let Some(history_id) = record.get("id").and_then(Value::as_i64) else {
             continue;
         };
@@ -157,7 +163,11 @@ fn run_sonarr_inventory_language_audit(
     redownload_options: RedownloadOptions,
     audit_options: AuditOptions,
 ) -> Result<AuditSummary> {
-    let items = client.sonarr_inventory_episode_files()?;
+    let items = if audit_options.episode_ids.is_empty() {
+        client.sonarr_inventory_episode_files()?
+    } else {
+        client.sonarr_inventory_episode_files_for_ids(&audit_options.episode_ids)?
+    };
     let mut summary = AuditSummary::default();
     let mut searched = 0usize;
 
@@ -510,6 +520,22 @@ impl ApiClient {
             if saw_old {
                 break;
             }
+        }
+        Ok(out)
+    }
+
+    fn sonarr_inventory_episode_files_for_ids(
+        &self,
+        episode_ids: &[i64],
+    ) -> Result<Vec<(i64, Value)>> {
+        let mut out = Vec::new();
+        for &episode_id in episode_ids {
+            let episode = self.sonarr_episode(episode_id)?;
+            let Some(file_id) = episode.get("episodeFileId").and_then(Value::as_i64) else {
+                continue;
+            };
+            let file = self.sonarr_episode_file(file_id)?;
+            out.push((episode_id, file));
         }
         Ok(out)
     }
@@ -1627,6 +1653,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::Inventory,
                 lookback_days: 30,
                 max_searches: 10,
+                episode_ids: Vec::new(),
             },
         )
         .unwrap();

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -4,7 +4,7 @@ use super::cache;
 use super::env_helpers::get_env_ignore_case;
 use super::language::{
     normalize_language_tag, parse_language_tokens, report_from_present, LanguageCheckReport,
-    LanguageRequirements,
+    LanguageRequirements, UntaggedRetagOptions,
 };
 use super::IntegrationKind;
 use crate::{ServarrLanguageAuditScope, ServarrLanguageCandidatePolicy};
@@ -43,6 +43,7 @@ pub struct AuditOptions {
     pub lookback_days: u32,
     pub max_searches: usize,
     pub episode_ids: Vec<i64>,
+    pub untagged_retag: UntaggedRetagOptions,
 }
 
 impl Default for AuditOptions {
@@ -52,6 +53,7 @@ impl Default for AuditOptions {
             lookback_days: 30,
             max_searches: 20,
             episode_ids: Vec::new(),
+            untagged_retag: UntaggedRetagOptions::default(),
         }
     }
 }
@@ -149,6 +151,7 @@ fn run_sonarr_history_language_audit(
             requirements,
             redownload_options,
             audit_options.max_searches,
+            &audit_options.untagged_retag,
             &mut searched,
             &mut summary,
         );
@@ -183,6 +186,7 @@ fn run_sonarr_inventory_language_audit(
             requirements,
             redownload_options,
             audit_options.max_searches,
+            &audit_options.untagged_retag,
             &mut searched,
             &mut summary,
         );
@@ -200,11 +204,21 @@ fn process_sonarr_language_audit_item(
     requirements: &LanguageRequirements,
     redownload_options: RedownloadOptions,
     max_searches: usize,
+    untagged_retag: &UntaggedRetagOptions,
     searched: &mut usize,
     summary: &mut AuditSummary,
 ) {
     summary.checked += 1;
-    let report = language_report_from_episode_file(&episode_file, requirements);
+    let mut report = language_report_from_episode_file(&episode_file, requirements);
+    if !report.satisfied() && client.kind == IntegrationKind::Sonarr && untagged_retag.enabled() {
+        report = maybe_retag_audit_file(
+            IntegrationKind::Sonarr,
+            &episode_file,
+            requirements,
+            untagged_retag,
+            report,
+        );
+    }
     record_language_audit_assessment(
         IntegrationKind::Sonarr,
         "sonarr:episodefile",
@@ -1052,6 +1066,52 @@ fn language_report_from_episode_file(
     report_from_present(audio, subtitles, requirements)
 }
 
+fn maybe_retag_audit_file(
+    kind: IntegrationKind,
+    media_file: &Value,
+    requirements: &LanguageRequirements,
+    untagged_retag: &UntaggedRetagOptions,
+    current_report: LanguageCheckReport,
+) -> LanguageCheckReport {
+    let Some(path) = media_file
+        .get("path")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+    else {
+        return current_report;
+    };
+    if !path.exists() {
+        return current_report;
+    }
+    match super::language::retag_unknown_streams(&path, requirements, untagged_retag) {
+        Ok(retag) if retag.changed() => {
+            info!(
+                "{} {}retagged unknown stream language metadata for '{}': audio={}, subtitles={}",
+                kind.label(),
+                if retag.dry_run { "would have " } else { "" },
+                path.display(),
+                retag.audio_streams,
+                retag.subtitle_streams
+            );
+            if retag.dry_run {
+                current_report
+            } else {
+                super::language::check_file(&path, requirements).unwrap_or(current_report)
+            }
+        }
+        Ok(_) => current_report,
+        Err(err) => {
+            warn!(
+                "{} inventory language audit failed to retag unknown stream metadata for '{}': {}",
+                kind.label(),
+                path.display(),
+                err
+            );
+            current_report
+        }
+    }
+}
+
 fn record_language_audit_assessment(
     kind: IntegrationKind,
     fallback_prefix: &str,
@@ -1654,6 +1714,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -1757,6 +1818,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -1846,6 +1908,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 1,
                 episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -1914,6 +1977,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: vec![77],
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -1974,6 +2038,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: vec![77],
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -2060,6 +2125,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -2134,6 +2200,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -2186,6 +2253,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();
@@ -2235,6 +2303,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
             },
         )
         .unwrap();

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -69,8 +69,15 @@ pub fn trigger_verified_redownload(
     if options.dry_run {
         return Ok(RedownloadOutcome::DryRun {
             summary: format!(
-                "would grab '{}' using {:?} policy ({}) and then blocklist the current history item if identifiable",
-                title, options.candidate_policy, evidence
+                "would grab '{}' using {:?} policy ({}) and then blocklist the current history item if identifiable{}",
+                title,
+                options.candidate_policy,
+                evidence,
+                if release_rejections_are_only_existing_file_cutoff(release) {
+                    "; accepting Arr's existing-file/cutoff rejection as a language-upgrade override"
+                } else {
+                    ""
+                }
             ),
         });
     }
@@ -279,19 +286,32 @@ fn select_verified_release<'a>(
 ) -> Option<&'a Value> {
     releases
         .iter()
-        .filter(|release| release_is_grabbable(release))
+        .filter(|release| release_can_be_language_upgrade_candidate(release))
         .filter(|release| release_satisfies_languages(release, requirements, policy))
         .max_by_key(|release| release_score(release))
 }
 
-fn release_is_grabbable(release: &Value) -> bool {
-    if release.get("rejected").and_then(Value::as_bool) == Some(true) {
-        return false;
-    }
+fn release_can_be_language_upgrade_candidate(release: &Value) -> bool {
     if release.get("downloadAllowed").and_then(Value::as_bool) == Some(false) {
         return false;
     }
-    true
+    if release.get("rejected").and_then(Value::as_bool) != Some(true) {
+        return true;
+    }
+    release_rejections_are_only_existing_file_cutoff(release)
+}
+
+fn release_rejections_are_only_existing_file_cutoff(release: &Value) -> bool {
+    let Some(rejections) = release.get("rejections").and_then(Value::as_array) else {
+        return false;
+    };
+    !rejections.is_empty()
+        && rejections.iter().all(|reason| {
+            let reason = reason.as_str().unwrap_or_default().to_ascii_lowercase();
+            reason.contains("existing file")
+                || reason.contains("meets cutoff")
+                || reason.contains("quality profile does not allow upgrades")
+        })
 }
 
 fn release_satisfies_languages(
@@ -818,6 +838,55 @@ mod tests {
         search.assert();
 
         env::remove_var("sonarr_episode_id");
+    }
+
+    #[test]
+    fn accepts_existing_file_cutoff_rejection_for_language_upgrade_candidate() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string(), "jpn".to_string()],
+            subtitles: vec!["eng".to_string()],
+        };
+        let releases = vec![json!({
+            "title":"Rent-a-Girlfriend S05E04 1080p Dual-Audio Multi-Subs",
+            "rejected": true,
+            "downloadAllowed": true,
+            "rejections":[
+                "Existing file and the Quality profile does not allow upgrades",
+                "Existing file meets cutoff: Unknown"
+            ],
+            "customFormatScore": 875
+        })];
+
+        assert!(select_verified_release(
+            &releases,
+            &req,
+            ServarrLanguageCandidatePolicy::CustomFormatOrTitle
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn still_rejects_unrelated_arr_rejections() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string(), "jpn".to_string()],
+            subtitles: vec!["eng".to_string()],
+        };
+        let releases = vec![json!({
+            "title":"Rent-a-Girlfriend S05E04 1080p Dual-Audio Multi-Subs",
+            "rejected": true,
+            "downloadAllowed": true,
+            "rejections":["Not enough seeders: 0. Minimum seeders: 1"],
+            "customFormatScore": 875
+        })];
+
+        assert!(select_verified_release(
+            &releases,
+            &req,
+            ServarrLanguageCandidatePolicy::CustomFormatOrTitle
+        )
+        .is_none());
     }
 
     #[test]

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -105,47 +105,19 @@ pub fn run_sonarr_language_audit(
         let Some(history_id) = record.get("id").and_then(Value::as_i64) else {
             continue;
         };
-        let episode = match client.sonarr_episode(episode_id) {
-            Ok(episode) => episode,
-            Err(err) => {
-                summary.errors += 1;
-                warn!(
-                    "Sonarr language audit could not fetch episode {}: {}",
-                    episode_id, err
-                );
-                continue;
-            }
-        };
-        let Some(file_id) = episode.get("episodeFileId").and_then(Value::as_i64) else {
+        let Some(episode_file) = client.sonarr_current_episode_file(episode_id, &mut summary)
+        else {
             continue;
-        };
-        let episode_file = match client.sonarr_episode_file(file_id) {
-            Ok(file) => file,
-            Err(err) => {
-                summary.errors += 1;
-                warn!(
-                    "Sonarr language audit could not fetch episode file {}: {}",
-                    file_id, err
-                );
-                continue;
-            }
         };
         summary.checked += 1;
         let report = language_report_from_episode_file(&episode_file, requirements);
-        let path = episode_file
-            .get("path")
-            .and_then(Value::as_str)
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(format!("sonarr:episodefile:{file_id}")));
-        if let Err(err) =
-            cache::record_assessment(IntegrationKind::Sonarr, &path, requirements, &report)
-        {
-            warn!(
-                "Sonarr language audit failed to update DPN cache for '{}': {}",
-                path.display(),
-                err
-            );
-        }
+        record_language_audit_assessment(
+            IntegrationKind::Sonarr,
+            "sonarr:episodefile",
+            &episode_file,
+            requirements,
+            &report,
+        );
         if report.satisfied() {
             continue;
         }
@@ -155,53 +127,16 @@ pub fn run_sonarr_language_audit(
         }
         searched += 1;
         summary.searched += 1;
-        match client.redownload_for_target(
+        client.apply_audit_redownload_outcome(
             Target::SonarrEpisode { episode_id },
             history_id,
             requirements,
             redownload_options,
-        ) {
-            Ok(RedownloadOutcome::Grabbed { title }) => {
-                summary.grabbed += 1;
-                info!(
-                    "Sonarr language audit grabbed replacement for episode {}: {}",
-                    episode_id, title
-                );
-            }
-            Ok(RedownloadOutcome::DryRun { summary: details }) => {
-                summary.dry_run += 1;
-                info!(
-                    "Sonarr language audit dry-run for episode {}: {}",
-                    episode_id, details
-                );
-            }
-            Ok(RedownloadOutcome::NoVerifiedRelease { reason }) => {
-                summary.no_candidate += 1;
-                info!(
-                    "Sonarr language audit found no replacement for episode {}: {}",
-                    episode_id, reason
-                );
-            }
-            Err(err) => {
-                summary.errors += 1;
-                warn!(
-                    "Sonarr language audit replacement check failed for episode {}: {}",
-                    episode_id, err
-                );
-            }
-        }
+            &mut summary,
+        );
     }
 
-    info!(
-        "Sonarr language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, errors={}",
-        summary.checked,
-        summary.missing,
-        summary.searched,
-        summary.dry_run,
-        summary.grabbed,
-        summary.no_candidate,
-        summary.errors
-    );
+    log_audit_summary("Sonarr", &summary);
     Ok(summary)
 }
 
@@ -224,47 +159,18 @@ pub fn run_radarr_language_audit(
         let Some(history_id) = record.get("id").and_then(Value::as_i64) else {
             continue;
         };
-        let movie = match client.radarr_movie(movie_id) {
-            Ok(movie) => movie,
-            Err(err) => {
-                summary.errors += 1;
-                warn!(
-                    "Radarr language audit could not fetch movie {}: {}",
-                    movie_id, err
-                );
-                continue;
-            }
-        };
-        let Some(file_id) = movie.get("movieFileId").and_then(Value::as_i64) else {
+        let Some(movie_file) = client.radarr_current_movie_file(movie_id, &mut summary) else {
             continue;
-        };
-        let movie_file = match client.radarr_movie_file(file_id) {
-            Ok(file) => file,
-            Err(err) => {
-                summary.errors += 1;
-                warn!(
-                    "Radarr language audit could not fetch movie file {}: {}",
-                    file_id, err
-                );
-                continue;
-            }
         };
         summary.checked += 1;
         let report = language_report_from_episode_file(&movie_file, requirements);
-        let path = movie_file
-            .get("path")
-            .and_then(Value::as_str)
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(format!("radarr:moviefile:{file_id}")));
-        if let Err(err) =
-            cache::record_assessment(IntegrationKind::Radarr, &path, requirements, &report)
-        {
-            warn!(
-                "Radarr language audit failed to update DPN cache for '{}': {}",
-                path.display(),
-                err
-            );
-        }
+        record_language_audit_assessment(
+            IntegrationKind::Radarr,
+            "radarr:moviefile",
+            &movie_file,
+            requirements,
+            &report,
+        );
         if report.satisfied() {
             continue;
         }
@@ -274,53 +180,16 @@ pub fn run_radarr_language_audit(
         }
         searched += 1;
         summary.searched += 1;
-        match client.redownload_for_target(
+        client.apply_audit_redownload_outcome(
             Target::RadarrMovie { movie_id },
             history_id,
             requirements,
             redownload_options,
-        ) {
-            Ok(RedownloadOutcome::Grabbed { title }) => {
-                summary.grabbed += 1;
-                info!(
-                    "Radarr language audit grabbed replacement for movie {}: {}",
-                    movie_id, title
-                );
-            }
-            Ok(RedownloadOutcome::DryRun { summary: details }) => {
-                summary.dry_run += 1;
-                info!(
-                    "Radarr language audit dry-run for movie {}: {}",
-                    movie_id, details
-                );
-            }
-            Ok(RedownloadOutcome::NoVerifiedRelease { reason }) => {
-                summary.no_candidate += 1;
-                info!(
-                    "Radarr language audit found no replacement for movie {}: {}",
-                    movie_id, reason
-                );
-            }
-            Err(err) => {
-                summary.errors += 1;
-                warn!(
-                    "Radarr language audit replacement check failed for movie {}: {}",
-                    movie_id, err
-                );
-            }
-        }
+            &mut summary,
+        );
     }
 
-    info!(
-        "Radarr language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, errors={}",
-        summary.checked,
-        summary.missing,
-        summary.searched,
-        summary.dry_run,
-        summary.grabbed,
-        summary.no_candidate,
-        summary.errors
-    );
+    log_audit_summary("Radarr", &summary);
     Ok(summary)
 }
 
@@ -529,6 +398,66 @@ impl ApiClient {
             }
         }
         Ok(out)
+    }
+
+    fn sonarr_current_episode_file(
+        &self,
+        episode_id: i64,
+        summary: &mut AuditSummary,
+    ) -> Option<Value> {
+        let episode = match self.sonarr_episode(episode_id) {
+            Ok(episode) => episode,
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr language audit could not fetch episode {}: {}",
+                    episode_id, err
+                );
+                return None;
+            }
+        };
+        let file_id = episode.get("episodeFileId").and_then(Value::as_i64)?;
+        match self.sonarr_episode_file(file_id) {
+            Ok(file) => Some(file),
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr language audit could not fetch episode file {}: {}",
+                    file_id, err
+                );
+                None
+            }
+        }
+    }
+
+    fn radarr_current_movie_file(
+        &self,
+        movie_id: i64,
+        summary: &mut AuditSummary,
+    ) -> Option<Value> {
+        let movie = match self.radarr_movie(movie_id) {
+            Ok(movie) => movie,
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Radarr language audit could not fetch movie {}: {}",
+                    movie_id, err
+                );
+                return None;
+            }
+        };
+        let file_id = movie.get("movieFileId").and_then(Value::as_i64)?;
+        match self.radarr_movie_file(file_id) {
+            Ok(file) => Some(file),
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Radarr language audit could not fetch movie file {}: {}",
+                    file_id, err
+                );
+                None
+            }
+        }
     }
 
     fn sonarr_episode(&self, episode_id: i64) -> Result<Value> {
@@ -740,6 +669,60 @@ impl ApiClient {
         Ok(())
     }
 
+    fn apply_audit_redownload_outcome(
+        &self,
+        target: Target,
+        history_id: i64,
+        requirements: &LanguageRequirements,
+        options: RedownloadOptions,
+        summary: &mut AuditSummary,
+    ) {
+        let label = self.kind.label();
+        let target_id = target.id();
+        match self.redownload_for_target(target, history_id, requirements, options) {
+            Ok(RedownloadOutcome::Grabbed { title }) => {
+                summary.grabbed += 1;
+                info!(
+                    "{} language audit grabbed replacement for {} {}: {}",
+                    label,
+                    target.noun(),
+                    target_id,
+                    title
+                );
+            }
+            Ok(RedownloadOutcome::DryRun { summary: details }) => {
+                summary.dry_run += 1;
+                info!(
+                    "{} language audit dry-run for {} {}: {}",
+                    label,
+                    target.noun(),
+                    target_id,
+                    details
+                );
+            }
+            Ok(RedownloadOutcome::NoVerifiedRelease { reason }) => {
+                summary.no_candidate += 1;
+                info!(
+                    "{} language audit found no replacement for {} {}: {}",
+                    label,
+                    target.noun(),
+                    target_id,
+                    reason
+                );
+            }
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "{} language audit replacement check failed for {} {}: {}",
+                    label,
+                    target.noun(),
+                    target_id,
+                    err
+                );
+            }
+        }
+    }
+
     fn find_current_history_id(&self, kind: IntegrationKind) -> Result<Option<i64>> {
         if let Some(id) = explicit_history_id(kind) {
             return Ok(Some(id));
@@ -864,6 +847,49 @@ fn language_report_from_episode_file(
     report_from_present(audio, subtitles, requirements)
 }
 
+fn record_language_audit_assessment(
+    kind: IntegrationKind,
+    fallback_prefix: &str,
+    media_file: &Value,
+    requirements: &LanguageRequirements,
+    report: &LanguageCheckReport,
+) {
+    let path = media_file
+        .get("path")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let id = media_file
+                .get("id")
+                .and_then(Value::as_i64)
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            PathBuf::from(format!("{fallback_prefix}:{id}"))
+        });
+    if let Err(err) = cache::record_assessment(kind, &path, requirements, report) {
+        warn!(
+            "{} language audit failed to update DPN cache for '{}': {}",
+            kind.label(),
+            path.display(),
+            err
+        );
+    }
+}
+
+fn log_audit_summary(label: &str, summary: &AuditSummary) {
+    info!(
+        "{} language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, errors={}",
+        label,
+        summary.checked,
+        summary.missing,
+        summary.searched,
+        summary.dry_run,
+        summary.grabbed,
+        summary.no_candidate,
+        summary.errors
+    );
+}
+
 fn current_day_number() -> i64 {
     let unix_days = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -899,6 +925,20 @@ enum Target {
 }
 
 impl Target {
+    fn id(self) -> i64 {
+        match self {
+            Target::SonarrEpisode { episode_id } => episode_id,
+            Target::RadarrMovie { movie_id } => movie_id,
+        }
+    }
+
+    fn noun(self) -> &'static str {
+        match self {
+            Target::SonarrEpisode { .. } => "episode",
+            Target::RadarrMovie { .. } => "movie",
+        }
+    }
+
     fn from_env(kind: IntegrationKind) -> Result<Self> {
         match kind {
             IntegrationKind::Sonarr => env_int_list(&[
@@ -960,6 +1000,8 @@ fn release_rejections_are_only_existing_file_cutoff(release: &Value) -> bool {
             reason.contains("existing file")
                 || reason.contains("meets cutoff")
                 || reason.contains("quality profile does not allow upgrades")
+                || reason.contains("equal or higher custom format score")
+                || reason.contains("equal or higher preference")
         })
 }
 
@@ -1497,12 +1539,14 @@ mod tests {
             subtitles: vec!["eng".to_string()],
         };
         let releases = vec![json!({
-            "title":"Rent-a-Girlfriend S05E04 1080p Dual-Audio Multi-Subs",
+            "title":"language upgrade candidate 1080p Dual-Audio Multi-Subs",
             "rejected": true,
             "downloadAllowed": true,
             "rejections":[
                 "Existing file and the Quality profile does not allow upgrades",
-                "Existing file meets cutoff: Unknown"
+                "Existing file meets cutoff: Unknown",
+                "Existing file on disk has a equal or higher Custom Format score: 0",
+                "Existing file on disk is of equal or higher preference: Remux-1080p"
             ],
             "customFormatScore": 875
         })];
@@ -1523,7 +1567,7 @@ mod tests {
             subtitles: vec!["eng".to_string()],
         };
         let releases = vec![json!({
-            "title":"Rent-a-Girlfriend S05E04 1080p Dual-Audio Multi-Subs",
+            "title":"language upgrade candidate 1080p Dual-Audio Multi-Subs",
             "rejected": true,
             "downloadAllowed": true,
             "rejections":["Not enough seeders: 0. Minimum seeders: 1"],

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -1,0 +1,151 @@
+//! Minimal Sonarr/Radarr API helpers used by optional language mismatch handling.
+
+use super::env_helpers::get_env_ignore_case;
+use super::IntegrationKind;
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::json;
+
+#[derive(Debug, Clone, Default)]
+pub struct ApiSettings {
+    pub url: Option<String>,
+    pub api_key: Option<String>,
+}
+
+pub fn trigger_redownload_search(kind: IntegrationKind, settings: &ApiSettings) -> Result<()> {
+    let base_url = settings
+        .url
+        .clone()
+        .or_else(|| env_url(kind))
+        .ok_or_else(|| {
+            anyhow!(
+                "{} API URL is required to trigger a redownload search",
+                kind.label()
+            )
+        })?;
+    let api_key = settings
+        .api_key
+        .clone()
+        .or_else(|| env_api_key(kind))
+        .ok_or_else(|| {
+            anyhow!(
+                "{} API key is required to trigger a redownload search",
+                kind.label()
+            )
+        })?;
+
+    let body = match kind {
+        IntegrationKind::Sonarr => {
+            let episode_ids = env_int_list(&[
+                "sonarr_episodefile_episodeids",
+                "sonarr_episodefile_episode_ids",
+                "sonarr_episode_ids",
+                "sonarr_episode_id",
+            ]);
+            if episode_ids.is_empty() {
+                bail!(
+                    "Sonarr language mismatch detected, but no episode id env var was available to trigger EpisodeSearch"
+                );
+            }
+            json!({ "name": "EpisodeSearch", "episodeIds": episode_ids })
+        }
+        IntegrationKind::Radarr => {
+            let movie_ids = env_int_list(&["radarr_movie_id", "radarr_moviefile_movie_id"]);
+            if movie_ids.is_empty() {
+                bail!(
+                    "Radarr language mismatch detected, but no movie id env var was available to trigger MoviesSearch"
+                );
+            }
+            json!({ "name": "MoviesSearch", "movieIds": movie_ids })
+        }
+    };
+
+    let endpoint = format!("{}/api/v3/command", base_url.trim_end_matches('/'));
+    let response = ureq::post(&endpoint)
+        .set("X-Api-Key", &api_key)
+        .set("Content-Type", "application/json")
+        .send_string(&body.to_string())
+        .with_context(|| format!("requesting {} redownload search", kind.label()))?;
+
+    if !(200..300).contains(&response.status()) {
+        bail!(
+            "{} redownload search request failed with HTTP {}",
+            kind.label(),
+            response.status()
+        );
+    }
+
+    Ok(())
+}
+
+fn env_url(kind: IntegrationKind) -> Option<String> {
+    match kind {
+        IntegrationKind::Sonarr => {
+            first_env(&["DIRECT_PLAY_NICE_SONARR_URL", "SONARR_URL", "sonarr_url"])
+        }
+        IntegrationKind::Radarr => {
+            first_env(&["DIRECT_PLAY_NICE_RADARR_URL", "RADARR_URL", "radarr_url"])
+        }
+    }
+}
+
+fn env_api_key(kind: IntegrationKind) -> Option<String> {
+    match kind {
+        IntegrationKind::Sonarr => first_env(&[
+            "DIRECT_PLAY_NICE_SONARR_API_KEY",
+            "SONARR_API_KEY",
+            "sonarr_api_key",
+            "sonarr_apikey",
+        ]),
+        IntegrationKind::Radarr => first_env(&[
+            "DIRECT_PLAY_NICE_RADARR_API_KEY",
+            "RADARR_API_KEY",
+            "radarr_api_key",
+            "radarr_apikey",
+        ]),
+    }
+}
+
+fn first_env(keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .filter_map(|key| get_env_ignore_case(key))
+        .map(|value| value.trim().to_string())
+        .find(|value| !value.is_empty())
+}
+
+fn env_int_list(keys: &[&str]) -> Vec<i64> {
+    for key in keys {
+        if let Some(raw) = get_env_ignore_case(key) {
+            let ids = raw
+                .split(['|', ',', ';', ' '])
+                .filter_map(|part| part.trim().parse::<i64>().ok())
+                .collect::<Vec<_>>();
+            if !ids.is_empty() {
+                return ids;
+            }
+        }
+    }
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn env_int_list_accepts_common_delimiters() {
+        let _guard = env_lock();
+        env::set_var("sonarr_episodefile_episodeids", "10|11,12;13 14");
+        assert_eq!(
+            env_int_list(&["sonarr_episodefile_episodeids"]),
+            vec![10, 11, 12, 13, 14]
+        );
+        env::remove_var("sonarr_episodefile_episodeids");
+    }
+}

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -1,9 +1,12 @@
 //! Minimal Sonarr/Radarr API helpers used by optional language mismatch handling.
 
 use super::env_helpers::get_env_ignore_case;
+use super::language::{normalize_language_tag, LanguageRequirements};
 use super::IntegrationKind;
 use anyhow::{anyhow, bail, Context, Result};
-use serde_json::json;
+use log::{info, warn};
+use serde_json::Value;
+use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, Default)]
 pub struct ApiSettings {
@@ -11,70 +14,331 @@ pub struct ApiSettings {
     pub api_key: Option<String>,
 }
 
-pub fn trigger_redownload_search(kind: IntegrationKind, settings: &ApiSettings) -> Result<()> {
-    let base_url = settings
-        .url
-        .clone()
-        .or_else(|| env_url(kind))
-        .ok_or_else(|| {
-            anyhow!(
-                "{} API URL is required to trigger a redownload search",
-                kind.label()
-            )
-        })?;
-    let api_key = settings
-        .api_key
-        .clone()
-        .or_else(|| env_api_key(kind))
-        .ok_or_else(|| {
-            anyhow!(
-                "{} API key is required to trigger a redownload search",
-                kind.label()
-            )
-        })?;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedownloadOutcome {
+    Grabbed { title: String },
+    NoVerifiedRelease { reason: String },
+}
 
-    let body = match kind {
-        IntegrationKind::Sonarr => {
-            let episode_ids = env_int_list(&[
+pub fn trigger_verified_redownload(
+    kind: IntegrationKind,
+    settings: &ApiSettings,
+    requirements: &LanguageRequirements,
+) -> Result<RedownloadOutcome> {
+    let client = ApiClient::from_settings(kind, settings)?;
+    let target = Target::from_env(kind)?;
+    let releases = client.search_releases(&target)?;
+    let Some(release) = select_verified_release(&releases, requirements) else {
+        return Ok(RedownloadOutcome::NoVerifiedRelease {
+            reason: format!(
+                "{} manual search returned no approved release with verified required audio{} languages",
+                kind.label(),
+                if requirements.subtitles.is_empty() {
+                    ""
+                } else {
+                    "/subtitle"
+                }
+            ),
+        });
+    };
+
+    let Some(history_id) = client.find_current_history_id(kind)? else {
+        bail!(
+            "{} found a verified replacement but could not identify the current download history record to blacklist; refusing to grab replacement.",
+            kind.label()
+        );
+    };
+
+    let title = release_title(release).unwrap_or_else(|| "<unknown release>".to_string());
+    client.grab_release(release)?;
+    client.mark_history_failed(history_id)?;
+    info!(
+        "Marked existing {} download history record {} as failed/blocklisted after grabbing replacement.",
+        kind.label(),
+        history_id
+    );
+    Ok(RedownloadOutcome::Grabbed { title })
+}
+
+#[derive(Debug, Clone)]
+struct ApiClient {
+    kind: IntegrationKind,
+    base_url: String,
+    api_key: String,
+}
+
+impl ApiClient {
+    fn from_settings(kind: IntegrationKind, settings: &ApiSettings) -> Result<Self> {
+        let base_url = settings
+            .url
+            .clone()
+            .or_else(|| env_url(kind))
+            .ok_or_else(|| {
+                anyhow!(
+                    "{} API URL is required to inspect and grab a verified redownload",
+                    kind.label()
+                )
+            })?;
+        let api_key = settings
+            .api_key
+            .clone()
+            .or_else(|| env_api_key(kind))
+            .ok_or_else(|| {
+                anyhow!(
+                    "{} API key is required to inspect and grab a verified redownload",
+                    kind.label()
+                )
+            })?;
+
+        Ok(Self {
+            kind,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+        })
+    }
+
+    fn search_releases(&self, target: &Target) -> Result<Vec<Value>> {
+        let endpoint = match target {
+            Target::SonarrEpisode { episode_id } => {
+                format!("{}/api/v3/release?episodeId={}", self.base_url, episode_id)
+            }
+            Target::RadarrMovie { movie_id } => {
+                format!("{}/api/v3/release?movieId={}", self.base_url, movie_id)
+            }
+        };
+        let response = self
+            .get(&endpoint)
+            .with_context(|| format!("requesting {} manual release search", self.kind.label()))?;
+        response.as_array().cloned().ok_or_else(|| {
+            anyhow!(
+                "{} release search did not return an array",
+                self.kind.label()
+            )
+        })
+    }
+
+    fn grab_release(&self, release: &Value) -> Result<()> {
+        let endpoint = format!("{}/api/v3/release", self.base_url);
+        self.post_json(&endpoint, release)
+            .with_context(|| format!("grabbing selected {} release", self.kind.label()))?;
+        Ok(())
+    }
+
+    fn mark_history_failed(&self, history_id: i64) -> Result<()> {
+        let endpoint = format!("{}/api/v3/history/failed/{}", self.base_url, history_id);
+        self.post_json(&endpoint, &Value::Null)
+            .with_context(|| format!("marking {} history item failed", self.kind.label()))?;
+        Ok(())
+    }
+
+    fn find_current_history_id(&self, kind: IntegrationKind) -> Result<Option<i64>> {
+        if let Some(id) = explicit_history_id(kind) {
+            return Ok(Some(id));
+        }
+        let Some(download_id) = download_id(kind) else {
+            warn!(
+                "{} download id env var not available; cannot resolve history record for blocklisting.",
+                kind.label()
+            );
+            return Ok(None);
+        };
+        let endpoint = format!(
+            "{}/api/v3/history?page=1&pageSize=10&sortKey=date&sortDirection=descending&downloadId={}",
+            self.base_url,
+            url_encode(&download_id)
+        );
+        let response = self
+            .get(&endpoint)
+            .with_context(|| format!("looking up {} history by download id", self.kind.label()))?;
+        let records = response
+            .get("records")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        Ok(records
+            .iter()
+            .filter_map(|record| record.get("id").and_then(Value::as_i64))
+            .next())
+    }
+
+    fn get(&self, endpoint: &str) -> Result<Value> {
+        let response = ureq::get(endpoint)
+            .set("X-Api-Key", &self.api_key)
+            .call()
+            .with_context(|| format!("GET {}", endpoint))?;
+        read_json_response(response)
+    }
+
+    fn post_json(&self, endpoint: &str, body: &Value) -> Result<Value> {
+        let request = ureq::post(endpoint)
+            .set("X-Api-Key", &self.api_key)
+            .set("Content-Type", "application/json");
+        let response = if body.is_null() {
+            request.call()
+        } else {
+            request.send_string(&body.to_string())
+        }
+        .with_context(|| format!("POST {}", endpoint))?;
+        read_json_response(response)
+    }
+}
+
+fn read_json_response(response: ureq::Response) -> Result<Value> {
+    if !(200..300).contains(&response.status()) {
+        bail!("HTTP request failed with status {}", response.status());
+    }
+    let text = response.into_string()?;
+    if text.trim().is_empty() {
+        return Ok(Value::Null);
+    }
+    serde_json::from_str(&text).context("parsing JSON response")
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Target {
+    SonarrEpisode { episode_id: i64 },
+    RadarrMovie { movie_id: i64 },
+}
+
+impl Target {
+    fn from_env(kind: IntegrationKind) -> Result<Self> {
+        match kind {
+            IntegrationKind::Sonarr => env_int_list(&[
                 "sonarr_episodefile_episodeids",
                 "sonarr_episodefile_episode_ids",
                 "sonarr_episode_ids",
                 "sonarr_episode_id",
-            ]);
-            if episode_ids.is_empty() {
-                bail!(
-                    "Sonarr language mismatch detected, but no episode id env var was available to trigger EpisodeSearch"
-                );
-            }
-            json!({ "name": "EpisodeSearch", "episodeIds": episode_ids })
+            ])
+            .into_iter()
+            .next()
+            .map(|episode_id| Target::SonarrEpisode { episode_id })
+            .ok_or_else(|| {
+                anyhow!(
+                    "Sonarr language mismatch detected, but no episode id env var was available for manual release search"
+                )
+            }),
+            IntegrationKind::Radarr => env_int_list(&["radarr_movie_id", "radarr_moviefile_movie_id"])
+                .into_iter()
+                .next()
+                .map(|movie_id| Target::RadarrMovie { movie_id })
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Radarr language mismatch detected, but no movie id env var was available for manual release search"
+                    )
+                }),
         }
-        IntegrationKind::Radarr => {
-            let movie_ids = env_int_list(&["radarr_movie_id", "radarr_moviefile_movie_id"]);
-            if movie_ids.is_empty() {
-                bail!(
-                    "Radarr language mismatch detected, but no movie id env var was available to trigger MoviesSearch"
-                );
-            }
-            json!({ "name": "MoviesSearch", "movieIds": movie_ids })
-        }
-    };
+    }
+}
 
-    let endpoint = format!("{}/api/v3/command", base_url.trim_end_matches('/'));
-    let response = ureq::post(&endpoint)
-        .set("X-Api-Key", &api_key)
-        .set("Content-Type", "application/json")
-        .send_string(&body.to_string())
-        .with_context(|| format!("requesting {} redownload search", kind.label()))?;
+fn select_verified_release<'a>(
+    releases: &'a [Value],
+    requirements: &LanguageRequirements,
+) -> Option<&'a Value> {
+    releases
+        .iter()
+        .filter(|release| release_is_grabbable(release))
+        .filter(|release| release_satisfies_languages(release, requirements))
+        .max_by_key(|release| release_score(release))
+}
 
-    if !(200..300).contains(&response.status()) {
-        bail!(
-            "{} redownload search request failed with HTTP {}",
-            kind.label(),
-            response.status()
-        );
+fn release_is_grabbable(release: &Value) -> bool {
+    if release.get("rejected").and_then(Value::as_bool) == Some(true) {
+        return false;
+    }
+    if release.get("downloadAllowed").and_then(Value::as_bool) == Some(false) {
+        return false;
+    }
+    true
+}
+
+fn release_satisfies_languages(release: &Value, requirements: &LanguageRequirements) -> bool {
+    let langs = release_languages(release);
+    let missing_audio = requirements.audio.iter().any(|lang| !langs.contains(lang));
+    if missing_audio {
+        return false;
     }
 
-    Ok(())
+    if requirements.subtitles.is_empty() {
+        return true;
+    }
+
+    // Sonarr/Radarr release resources do not reliably expose subtitle-track
+    // language availability. Only accept a candidate if a future API/provider
+    // includes explicit subtitle language fields we can normalize.
+    let subtitle_langs = release_subtitle_languages(release);
+    !subtitle_langs.is_empty()
+        && requirements
+            .subtitles
+            .iter()
+            .all(|lang| subtitle_langs.contains(lang))
+}
+
+fn release_languages(release: &Value) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    collect_language_values(release.get("languages"), &mut out);
+    collect_language_values(release.get("language"), &mut out);
+    out
+}
+
+fn release_subtitle_languages(release: &Value) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for key in ["subtitleLanguages", "subtitles", "subtitleLanguage"] {
+        collect_language_values(release.get(key), &mut out);
+    }
+    out
+}
+
+fn collect_language_values(value: Option<&Value>, out: &mut BTreeSet<String>) {
+    match value {
+        Some(Value::Array(items)) => {
+            for item in items {
+                collect_language_values(Some(item), out);
+            }
+        }
+        Some(Value::Object(map)) => {
+            for key in [
+                "name",
+                "nameLower",
+                "language",
+                "isoCode",
+                "iso6392",
+                "code",
+            ] {
+                if let Some(lang) = map
+                    .get(key)
+                    .and_then(Value::as_str)
+                    .and_then(normalize_language_tag)
+                {
+                    out.insert(lang);
+                }
+            }
+        }
+        Some(Value::String(raw)) => {
+            if let Some(lang) = normalize_language_tag(raw) {
+                out.insert(lang);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn release_score(release: &Value) -> i64 {
+    release
+        .get("customFormatScore")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + release
+            .get("qualityWeight")
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+}
+
+fn release_title(release: &Value) -> Option<String> {
+    release
+        .get("title")
+        .or_else(|| release.get("releaseTitle"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
 }
 
 fn env_url(kind: IntegrationKind) -> Option<String> {
@@ -105,6 +369,29 @@ fn env_api_key(kind: IntegrationKind) -> Option<String> {
     }
 }
 
+fn explicit_history_id(kind: IntegrationKind) -> Option<i64> {
+    match kind {
+        IntegrationKind::Sonarr => first_env(&[
+            "DIRECT_PLAY_NICE_SONARR_HISTORY_ID",
+            "sonarr_history_id",
+            "sonarr_download_history_id",
+        ]),
+        IntegrationKind::Radarr => first_env(&[
+            "DIRECT_PLAY_NICE_RADARR_HISTORY_ID",
+            "radarr_history_id",
+            "radarr_download_history_id",
+        ]),
+    }
+    .and_then(|raw| raw.parse().ok())
+}
+
+fn download_id(kind: IntegrationKind) -> Option<String> {
+    match kind {
+        IntegrationKind::Sonarr => first_env(&["sonarr_download_id", "sonarr_downloadid"]),
+        IntegrationKind::Radarr => first_env(&["radarr_download_id", "radarr_downloadid"]),
+    }
+}
+
 fn first_env(keys: &[&str]) -> Option<String> {
     keys.iter()
         .filter_map(|key| get_env_ignore_case(key))
@@ -127,9 +414,22 @@ fn env_int_list(keys: &[&str]) -> Vec<i64> {
     Vec::new()
 }
 
+fn url_encode(input: &str) -> String {
+    input
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                vec![byte as char]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::env;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
@@ -147,5 +447,48 @@ mod tests {
             vec![10, 11, 12, 13, 14]
         );
         env::remove_var("sonarr_episodefile_episodeids");
+    }
+
+    #[test]
+    fn selects_only_grabbable_release_with_required_audio_language() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string()],
+            subtitles: Vec::new(),
+        };
+        let releases = vec![
+            json!({"title":"bad", "rejected": true, "languages":[{"name":"English"}], "customFormatScore": 100}),
+            json!({"title":"wrong language", "rejected": false, "languages":[{"name":"French"}], "customFormatScore": 200}),
+            json!({"title":"good", "rejected": false, "languages":[{"name":"English"}], "customFormatScore": 10}),
+        ];
+
+        let selected = select_verified_release(&releases, &req).unwrap();
+        assert_eq!(release_title(selected).as_deref(), Some("good"));
+    }
+
+    #[test]
+    fn rejects_subtitle_requirement_without_verified_subtitle_metadata() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string()],
+            subtitles: vec!["spa".to_string()],
+        };
+        let releases = vec![json!({"title":"ambiguous", "languages":[{"name":"English"}]})];
+        assert!(select_verified_release(&releases, &req).is_none());
+    }
+
+    #[test]
+    fn accepts_subtitle_requirement_when_explicit_metadata_exists() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string()],
+            subtitles: vec!["spa".to_string()],
+        };
+        let releases = vec![json!({
+            "title":"explicit subtitles",
+            "languages":[{"name":"English"}],
+            "subtitleLanguages":[{"name":"Spanish"}]
+        })];
+        assert!(select_verified_release(&releases, &req).is_some());
     }
 }

--- a/src/servarr/cache.rs
+++ b/src/servarr/cache.rs
@@ -3,6 +3,7 @@
 use super::language::{LanguageCheckReport, LanguageRequirements};
 use super::IntegrationKind;
 use anyhow::{Context, Result};
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
@@ -48,15 +49,32 @@ pub fn record_assessment(
         report: report.clone(),
     });
     records.sort_by(|a, b| a.path.cmp(&b.path));
-    fs::write(&cache_path, serde_json::to_vec_pretty(&records)?)
-        .with_context(|| format!("writing language cache '{}'", cache_path.display()))?;
+    let tmp_path = cache_path.with_extension("json.tmp");
+    fs::write(&tmp_path, serde_json::to_vec_pretty(&records)?)
+        .with_context(|| format!("writing language cache '{}'", tmp_path.display()))?;
+    fs::rename(&tmp_path, &cache_path).with_context(|| {
+        format!(
+            "renaming language cache '{}' to '{}'",
+            tmp_path.display(),
+            cache_path.display()
+        )
+    })?;
     Ok(())
 }
 
 fn read_records(path: &Path) -> Result<Vec<CacheRecord>> {
     match fs::read_to_string(path) {
-        Ok(contents) => serde_json::from_str(&contents)
-            .with_context(|| format!("parsing language cache '{}'", path.display())),
+        Ok(contents) => match serde_json::from_str(&contents) {
+            Ok(records) => Ok(records),
+            Err(err) => {
+                warn!(
+                    "Ignoring corrupt language cache '{}': {}",
+                    path.display(),
+                    err
+                );
+                Ok(Vec::new())
+            }
+        },
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
         Err(err) => {
             Err(err).with_context(|| format!("reading language cache '{}'", path.display()))
@@ -92,6 +110,40 @@ mod tests {
     fn env_lock() -> MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn ignores_corrupt_cache_file() {
+        let _guard = env_lock();
+        let tmp = TempDir::new().unwrap();
+        let cache_path = tmp.path().join("cache.json");
+        fs::write(&cache_path, "not json").unwrap();
+        env::set_var(CACHE_ENV_VAR, &cache_path);
+
+        let requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["jpn".to_string()],
+            subtitles: vec!["eng".to_string()],
+        };
+        let report = LanguageCheckReport {
+            present_audio: vec!["jpn".to_string()],
+            present_subtitles: vec!["eng".to_string()],
+            missing_audio: Vec::new(),
+            missing_subtitles: Vec::new(),
+        };
+
+        record_assessment(
+            IntegrationKind::Sonarr,
+            Path::new("/media/show.mkv"),
+            &requirements,
+            &report,
+        )
+        .unwrap();
+        assert!(fs::read_to_string(&cache_path)
+            .unwrap()
+            .contains("/media/show.mkv"));
+
+        env::remove_var(CACHE_ENV_VAR);
     }
 
     #[test]

--- a/src/servarr/cache.rs
+++ b/src/servarr/cache.rs
@@ -62,7 +62,7 @@ fn record_assessment_at_path(
     let tmp_path = cache_path.with_extension("json.tmp");
     fs::write(&tmp_path, serde_json::to_vec_pretty(&records)?)
         .with_context(|| format!("writing language cache '{}'", tmp_path.display()))?;
-    fs::rename(&tmp_path, &cache_path).with_context(|| {
+    fs::rename(&tmp_path, cache_path).with_context(|| {
         format!(
             "renaming language cache '{}' to '{}'",
             tmp_path.display(),

--- a/src/servarr/cache.rs
+++ b/src/servarr/cache.rs
@@ -30,12 +30,22 @@ pub fn record_assessment(
     let Some(cache_path) = resolve_cache_path() else {
         return Ok(());
     };
+    record_assessment_at_path(&cache_path, kind, path, requirements, report)
+}
+
+fn record_assessment_at_path(
+    cache_path: &Path,
+    kind: IntegrationKind,
+    path: &Path,
+    requirements: &LanguageRequirements,
+    report: &LanguageCheckReport,
+) -> Result<()> {
     if let Some(parent) = cache_path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("creating language cache directory '{}'", parent.display()))?;
     }
 
-    let mut records = read_records(&cache_path)?;
+    let mut records = read_records(cache_path)?;
     let path_string = path.to_string_lossy().into_owned();
     records.retain(|record| record.path != path_string);
     records.push(CacheRecord {
@@ -104,21 +114,13 @@ fn resolve_cache_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::TempDir;
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
-    }
 
     #[test]
     fn ignores_corrupt_cache_file() {
-        let _guard = env_lock();
         let tmp = TempDir::new().unwrap();
         let cache_path = tmp.path().join("cache.json");
         fs::write(&cache_path, "not json").unwrap();
-        env::set_var(CACHE_ENV_VAR, &cache_path);
 
         let requirements = LanguageRequirements {
             enabled: true,
@@ -132,7 +134,8 @@ mod tests {
             missing_subtitles: Vec::new(),
         };
 
-        record_assessment(
+        record_assessment_at_path(
+            &cache_path,
             IntegrationKind::Sonarr,
             Path::new("/media/show.mkv"),
             &requirements,
@@ -142,16 +145,12 @@ mod tests {
         assert!(fs::read_to_string(&cache_path)
             .unwrap()
             .contains("/media/show.mkv"));
-
-        env::remove_var(CACHE_ENV_VAR);
     }
 
     #[test]
     fn records_assessment_to_configured_cache_path() {
-        let _guard = env_lock();
         let tmp = TempDir::new().unwrap();
         let cache_path = tmp.path().join("cache.json");
-        env::set_var(CACHE_ENV_VAR, &cache_path);
 
         let requirements = LanguageRequirements {
             enabled: true,
@@ -165,7 +164,8 @@ mod tests {
             missing_subtitles: Vec::new(),
         };
 
-        record_assessment(
+        record_assessment_at_path(
+            &cache_path,
             IntegrationKind::Sonarr,
             Path::new("/media/show.mkv"),
             &requirements,
@@ -177,7 +177,5 @@ mod tests {
         assert!(contents.contains("/media/show.mkv"));
         assert!(contents.contains("jpn"));
         assert!(contents.contains("eng"));
-
-        env::remove_var(CACHE_ENV_VAR);
     }
 }

--- a/src/servarr/cache.rs
+++ b/src/servarr/cache.rs
@@ -1,0 +1,131 @@
+//! Best-effort cache for DPN's own Servarr language assessment state.
+
+use super::language::{LanguageCheckReport, LanguageRequirements};
+use super::IntegrationKind;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CACHE_ENV_VAR: &str = "DIRECT_PLAY_NICE_LANGUAGE_CACHE";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheRecord {
+    path: String,
+    kind: String,
+    checked_at_unix: u64,
+    requirements: LanguageRequirements,
+    report: LanguageCheckReport,
+}
+
+pub fn record_assessment(
+    kind: IntegrationKind,
+    path: &Path,
+    requirements: &LanguageRequirements,
+    report: &LanguageCheckReport,
+) -> Result<()> {
+    let Some(cache_path) = resolve_cache_path() else {
+        return Ok(());
+    };
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating language cache directory '{}'", parent.display()))?;
+    }
+
+    let mut records = read_records(&cache_path)?;
+    let path_string = path.to_string_lossy().into_owned();
+    records.retain(|record| record.path != path_string);
+    records.push(CacheRecord {
+        path: path_string,
+        kind: format!("{:?}", kind),
+        checked_at_unix: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        requirements: requirements.clone(),
+        report: report.clone(),
+    });
+    records.sort_by(|a, b| a.path.cmp(&b.path));
+    fs::write(&cache_path, serde_json::to_vec_pretty(&records)?)
+        .with_context(|| format!("writing language cache '{}'", cache_path.display()))?;
+    Ok(())
+}
+
+fn read_records(path: &Path) -> Result<Vec<CacheRecord>> {
+    match fs::read_to_string(path) {
+        Ok(contents) => serde_json::from_str(&contents)
+            .with_context(|| format!("parsing language cache '{}'", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(err) => {
+            Err(err).with_context(|| format!("reading language cache '{}'", path.display()))
+        }
+    }
+}
+
+fn resolve_cache_path() -> Option<PathBuf> {
+    if let Some(path) = env::var_os(CACHE_ENV_VAR) {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(cache_home) = env::var_os("XDG_CACHE_HOME") {
+        return Some(
+            PathBuf::from(cache_home)
+                .join("direct-play-nice")
+                .join("servarr-language-cache.json"),
+        );
+    }
+    env::var_os("HOME").map(|home| {
+        PathBuf::from(home)
+            .join(".cache")
+            .join("direct-play-nice")
+            .join("servarr-language-cache.json")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use tempfile::TempDir;
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn records_assessment_to_configured_cache_path() {
+        let _guard = env_lock();
+        let tmp = TempDir::new().unwrap();
+        let cache_path = tmp.path().join("cache.json");
+        env::set_var(CACHE_ENV_VAR, &cache_path);
+
+        let requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["jpn".to_string()],
+            subtitles: vec!["eng".to_string()],
+        };
+        let report = LanguageCheckReport {
+            present_audio: vec!["jpn".to_string()],
+            present_subtitles: vec!["eng".to_string()],
+            missing_audio: Vec::new(),
+            missing_subtitles: Vec::new(),
+        };
+
+        record_assessment(
+            IntegrationKind::Sonarr,
+            Path::new("/media/show.mkv"),
+            &requirements,
+            &report,
+        )
+        .unwrap();
+
+        let contents = fs::read_to_string(&cache_path).unwrap();
+        assert!(contents.contains("/media/show.mkv"));
+        assert!(contents.contains("jpn"));
+        assert!(contents.contains("eng"));
+
+        env::remove_var(CACHE_ENV_VAR);
+    }
+}

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -155,7 +155,7 @@ pub fn retag_unknown_streams(
     }
 
     let path_cstr = path_to_cstr(path)?;
-    let mut input_ctx = AVFormatContextInput::open(path_cstr.as_c_str())?;
+    let input_ctx = AVFormatContextInput::open(path_cstr.as_c_str())?;
     let mut report = UntaggedRetagReport {
         dry_run: options.dry_run,
         ..Default::default()
@@ -177,13 +177,8 @@ pub fn retag_unknown_streams(
         return Ok(report);
     }
 
-    remux_with_retagged_unknown_streams(
-        path,
-        &mut input_ctx,
-        options,
-        should_tag_audio,
-        should_tag_subtitles,
-    )?;
+    drop(input_ctx);
+    remux_with_retagged_unknown_streams(path, options, should_tag_audio, should_tag_subtitles)?;
     info!(
         "Retagged {} unknown audio stream(s) and {} unknown subtitle stream(s) in '{}'.",
         report.audio_streams,
@@ -195,11 +190,12 @@ pub fn retag_unknown_streams(
 
 fn remux_with_retagged_unknown_streams(
     path: &Path,
-    input_ctx: &mut AVFormatContextInput,
     options: &UntaggedRetagOptions,
     should_tag_audio: bool,
     should_tag_subtitles: bool,
 ) -> Result<()> {
+    let path_cstr = path_to_cstr(path)?;
+    let mut input_ctx = AVFormatContextInput::open(path_cstr.as_c_str())?;
     let tmp_path = retag_temp_path(path);
     let tmp_cstr = CString::new(tmp_path.to_string_lossy().to_string())
         .context("retag temp path has interior NUL")?;

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -5,19 +5,48 @@
 //! results and only grab a specific replacement when the release metadata proves
 //! the desired languages are available.
 
-use anyhow::Result;
-use rsmpeg::avformat::AVFormatContextInput;
+use anyhow::{Context, Result};
+use log::info;
+use rsmpeg::avformat::{AVFormatContextInput, AVFormatContextOutput};
 use rsmpeg::avutil::AVDictionary;
 use rsmpeg::ffi;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::ffi::CString;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LanguageRequirements {
     pub enabled: bool,
     pub audio: Vec<String>,
     pub subtitles: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UntaggedRetagOptions {
+    pub audio_language: Option<String>,
+    pub subtitle_language: Option<String>,
+    pub dry_run: bool,
+}
+
+impl UntaggedRetagOptions {
+    pub fn enabled(&self) -> bool {
+        self.audio_language.is_some() || self.subtitle_language.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UntaggedRetagReport {
+    pub audio_streams: usize,
+    pub subtitle_streams: usize,
+    pub dry_run: bool,
+}
+
+impl UntaggedRetagReport {
+    pub fn changed(&self) -> bool {
+        self.audio_streams > 0 || self.subtitle_streams > 0
+    }
 }
 
 impl LanguageRequirements {
@@ -105,6 +134,178 @@ pub fn check_file(path: &Path, requirements: &LanguageRequirements) -> Result<La
         subtitles.into_iter().collect(),
         requirements,
     ))
+}
+
+pub fn retag_unknown_streams(
+    path: &Path,
+    requirements: &LanguageRequirements,
+    options: &UntaggedRetagOptions,
+) -> Result<UntaggedRetagReport> {
+    if !options.enabled() {
+        return Ok(UntaggedRetagReport::default());
+    }
+
+    let initial_report = check_file(path, requirements)?;
+    let should_tag_audio =
+        options.audio_language.is_some() && !initial_report.missing_audio.is_empty();
+    let should_tag_subtitles =
+        options.subtitle_language.is_some() && !initial_report.missing_subtitles.is_empty();
+    if !should_tag_audio && !should_tag_subtitles {
+        return Ok(UntaggedRetagReport::default());
+    }
+
+    let path_cstr = path_to_cstr(path)?;
+    let mut input_ctx = AVFormatContextInput::open(path_cstr.as_c_str())?;
+    let mut report = UntaggedRetagReport {
+        dry_run: options.dry_run,
+        ..Default::default()
+    };
+
+    for stream in input_ctx.streams() {
+        let cp = stream.codecpar();
+        if stream_has_known_language(stream.metadata().as_deref()) {
+            continue;
+        }
+        match cp.codec_type {
+            ffi::AVMEDIA_TYPE_AUDIO if should_tag_audio => report.audio_streams += 1,
+            ffi::AVMEDIA_TYPE_SUBTITLE if should_tag_subtitles => report.subtitle_streams += 1,
+            _ => {}
+        }
+    }
+
+    if !report.changed() || options.dry_run {
+        return Ok(report);
+    }
+
+    remux_with_retagged_unknown_streams(
+        path,
+        &mut input_ctx,
+        options,
+        should_tag_audio,
+        should_tag_subtitles,
+    )?;
+    info!(
+        "Retagged {} unknown audio stream(s) and {} unknown subtitle stream(s) in '{}'.",
+        report.audio_streams,
+        report.subtitle_streams,
+        path.display()
+    );
+    Ok(report)
+}
+
+fn remux_with_retagged_unknown_streams(
+    path: &Path,
+    input_ctx: &mut AVFormatContextInput,
+    options: &UntaggedRetagOptions,
+    should_tag_audio: bool,
+    should_tag_subtitles: bool,
+) -> Result<()> {
+    let tmp_path = retag_temp_path(path);
+    let tmp_cstr = CString::new(tmp_path.to_string_lossy().to_string())
+        .context("retag temp path has interior NUL")?;
+    let mut output_ctx = AVFormatContextOutput::create(tmp_cstr.as_c_str())?;
+    let is_mkv = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| matches!(ext.to_ascii_lowercase().as_str(), "mkv" | "mka" | "mks"));
+
+    let mut stream_index_map = Vec::with_capacity(input_ctx.streams().len());
+    for stream in input_ctx.streams() {
+        let mut out_stream = output_ctx.new_stream();
+        out_stream.set_time_base(stream.time_base);
+        let mut codecpar = stream.codecpar().clone();
+        if is_mkv {
+            unsafe { (*codecpar.as_mut_ptr()).codec_tag = 0 };
+        }
+        out_stream.set_codecpar(codecpar);
+
+        let cp = stream.codecpar();
+        let metadata = if !stream_has_known_language(stream.metadata().as_deref()) {
+            match cp.codec_type {
+                ffi::AVMEDIA_TYPE_AUDIO if should_tag_audio => set_language_metadata(
+                    stream.metadata().as_deref().cloned(),
+                    options.audio_language.as_deref(),
+                ),
+                ffi::AVMEDIA_TYPE_SUBTITLE if should_tag_subtitles => set_language_metadata(
+                    stream.metadata().as_deref().cloned(),
+                    options.subtitle_language.as_deref(),
+                ),
+                _ => stream.metadata().as_deref().cloned(),
+            }
+        } else {
+            stream.metadata().as_deref().cloned()
+        };
+        out_stream.set_metadata(metadata);
+        stream_index_map.push(out_stream.index);
+    }
+
+    output_ctx
+        .write_header(&mut None)
+        .context("failed to write retagged output header")?;
+
+    loop {
+        let mut packet = match input_ctx.read_packet()? {
+            Some(packet) => packet,
+            None => break,
+        };
+        let input_index = packet.stream_index as usize;
+        let output_index = stream_index_map
+            .get(input_index)
+            .copied()
+            .with_context(|| format!("stream index {input_index} not mapped during retag remux"))?;
+        let input_time_base = input_ctx.streams()[input_index].time_base;
+        let output_time_base = output_ctx.streams()[output_index as usize].time_base;
+        packet.set_stream_index(output_index);
+        packet.rescale_ts(input_time_base, output_time_base);
+        output_ctx.interleaved_write_frame(&mut packet)?;
+    }
+
+    output_ctx.write_trailer()?;
+    drop(output_ctx);
+    replace_with_temp(&tmp_path, path, "retagging unknown stream languages")
+}
+
+fn stream_has_known_language(metadata: Option<&AVDictionary>) -> bool {
+    metadata
+        .and_then(extract_language_tag_from_metadata)
+        .and_then(|tag| normalize_language_tag(&tag))
+        .is_some()
+}
+
+fn set_language_metadata(
+    metadata: Option<AVDictionary>,
+    language: Option<&str>,
+) -> Option<AVDictionary> {
+    let language = language?;
+    let key = CString::new("language").ok()?;
+    let value = CString::new(language).ok()?;
+    Some(
+        metadata
+            .map(|dict| dict.set(&key, &value, 0))
+            .unwrap_or_else(|| AVDictionary::new(&key, &value, 0)),
+    )
+}
+
+fn retag_temp_path(path: &Path) -> PathBuf {
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("tmp");
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("media");
+    path.with_file_name(format!("{stem}.dpn-retag.tmp.{extension}"))
+}
+
+fn replace_with_temp(tmp_path: &Path, path: &Path, context: &str) -> Result<()> {
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path)
+            .with_context(|| format!("removing '{}' before {context}", path.display()))?;
+    }
+    fs::rename(tmp_path, path)
+        .with_context(|| format!("replacing '{}' after {context}", path.display()))
 }
 
 fn check_sets(
@@ -212,6 +413,119 @@ mod tests {
             parse_language_list(Some("en, eng, fr-FR, spa, und, ")),
             vec!["eng", "fra", "spa"]
         );
+    }
+
+    #[test]
+    fn retag_unknown_streams_dry_run_reports_unknown_audio_without_writing() {
+        let requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".into()],
+            subtitles: Vec::new(),
+        };
+        let options = UntaggedRetagOptions {
+            audio_language: Some("eng".to_string()),
+            subtitle_language: None,
+            dry_run: true,
+        };
+        let path = Path::new("/definitely/missing/file.mp4");
+        assert!(retag_unknown_streams(path, &requirements, &options).is_err());
+    }
+
+    #[cfg(feature = "ffmpeg-cli-tests")]
+    fn ffmpeg_present() -> bool {
+        std::process::Command::new("ffmpeg")
+            .arg("-version")
+            .output()
+            .is_ok_and(|out| out.status.success())
+    }
+
+    #[cfg(feature = "ffmpeg-cli-tests")]
+    fn make_audio_fixture(path: &Path, language: &str) {
+        let status = std::process::Command::new("ffmpeg")
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=0.2",
+                "-c:a",
+                "aac",
+                "-metadata:s:a:0",
+                &format!("language={language}"),
+            ])
+            .arg(path)
+            .status()
+            .expect("run ffmpeg audio fixture");
+        assert!(status.success(), "ffmpeg audio fixture failed");
+    }
+
+    #[cfg(feature = "ffmpeg-cli-tests")]
+    #[test]
+    fn retag_unknown_streams_sets_unknown_audio_language() {
+        if !ffmpeg_present() {
+            eprintln!(
+                "skipping retag_unknown_streams_sets_unknown_audio_language: ffmpeg not found"
+            );
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audio.mp4");
+        make_audio_fixture(&path, "und");
+        let requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".into()],
+            subtitles: Vec::new(),
+        };
+        assert_eq!(
+            check_file(&path, &requirements).unwrap().missing_audio,
+            vec!["eng"]
+        );
+        let report = retag_unknown_streams(
+            &path,
+            &requirements,
+            &UntaggedRetagOptions {
+                audio_language: Some("eng".to_string()),
+                subtitle_language: None,
+                dry_run: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(report.audio_streams, 1);
+        assert!(check_file(&path, &requirements).unwrap().satisfied());
+    }
+
+    #[cfg(feature = "ffmpeg-cli-tests")]
+    #[test]
+    fn retag_unknown_streams_does_not_overwrite_known_audio_language() {
+        if !ffmpeg_present() {
+            eprintln!("skipping retag_unknown_streams_does_not_overwrite_known_audio_language: ffmpeg not found");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audio.mp4");
+        make_audio_fixture(&path, "jpn");
+        let requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".into()],
+            subtitles: Vec::new(),
+        };
+        let report = retag_unknown_streams(
+            &path,
+            &requirements,
+            &UntaggedRetagOptions {
+                audio_language: Some("eng".to_string()),
+                subtitle_language: None,
+                dry_run: false,
+            },
+        )
+        .unwrap();
+        assert!(!report.changed());
+        let check = check_file(&path, &requirements).unwrap();
+        assert_eq!(check.present_audio, vec!["jpn"]);
+        assert_eq!(check.missing_audio, vec!["eng"]);
     }
 
     #[test]

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -52,14 +52,25 @@ impl LanguageCheckReport {
 }
 
 pub fn parse_language_list(raw: Option<&str>) -> Vec<String> {
-    raw.unwrap_or("")
-        .split(',')
+    parse_language_tokens(raw.unwrap_or(""))
+}
+
+pub fn parse_language_tokens(raw: &str) -> Vec<String> {
+    raw.split([',', '/', ';', '|', ' '])
         .map(str::trim)
         .filter(|entry| !entry.is_empty())
         .filter_map(normalize_language_tag)
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+pub fn report_from_present(
+    present_audio: Vec<String>,
+    present_subtitles: Vec<String>,
+    requirements: &LanguageRequirements,
+) -> LanguageCheckReport {
+    check_sets(present_audio, present_subtitles, requirements)
 }
 
 pub fn check_file(path: &Path, requirements: &LanguageRequirements) -> Result<LanguageCheckReport> {

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -9,10 +9,11 @@ use anyhow::Result;
 use rsmpeg::avformat::AVFormatContextInput;
 use rsmpeg::avutil::AVDictionary;
 use rsmpeg::ffi;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path::Path;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LanguageRequirements {
     pub enabled: bool,
     pub audio: Vec<String>,
@@ -25,7 +26,7 @@ impl LanguageRequirements {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LanguageCheckReport {
     pub present_audio: Vec<String>,
     pub present_subtitles: Vec<String>,

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -1,9 +1,9 @@
 //! Language requirement checks for Sonarr/Radarr-triggered runs.
 //!
-//! This module intentionally only inspects the already-imported media file. When
-//! requirements are not met, the API layer can ask Servarr to perform a monitored
-//! search; Sonarr/Radarr decide whether a replacement release is actually
-//! available and acceptable for the configured profiles.
+//! This module intentionally only inspects the already-imported media file.
+//! When requirements are not met, the API layer may ask Servarr for manual-search
+//! results and only grab a specific replacement when the release metadata proves
+//! the desired languages are available.
 
 use anyhow::Result;
 use rsmpeg::avformat::AVFormatContextInput;
@@ -144,7 +144,7 @@ fn extract_language_tag_from_metadata(dict: &AVDictionary) -> Option<String> {
     None
 }
 
-fn normalize_language_tag(input: &str) -> Option<String> {
+pub(super) fn normalize_language_tag(input: &str) -> Option<String> {
     let primary = input
         .trim()
         .to_ascii_lowercase()
@@ -157,16 +157,16 @@ fn normalize_language_tag(input: &str) -> Option<String> {
     }
 
     let normalized = match primary.as_str() {
-        "en" => "eng",
-        "fr" | "fre" => "fra",
-        "es" => "spa",
-        "de" | "ger" => "deu",
-        "it" => "ita",
-        "pt" => "por",
-        "ja" => "jpn",
-        "ko" => "kor",
-        "zh" => "zho",
-        "ru" => "rus",
+        "en" | "eng" | "english" => "eng",
+        "fr" | "fre" | "fra" | "french" => "fra",
+        "es" | "spa" | "spanish" => "spa",
+        "de" | "ger" | "deu" | "german" => "deu",
+        "it" | "ita" | "italian" => "ita",
+        "pt" | "por" | "portuguese" => "por",
+        "ja" | "jpn" | "japanese" => "jpn",
+        "ko" | "kor" | "korean" => "kor",
+        "zh" | "zho" | "chi" | "chinese" => "zho",
+        "ru" | "rus" | "russian" => "rus",
         "nl" => "nld",
         "pl" => "pol",
         "sv" => "swe",

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -1,0 +1,224 @@
+//! Language requirement checks for Sonarr/Radarr-triggered runs.
+//!
+//! This module intentionally only inspects the already-imported media file. When
+//! requirements are not met, the API layer can ask Servarr to perform a monitored
+//! search; Sonarr/Radarr decide whether a replacement release is actually
+//! available and acceptable for the configured profiles.
+
+use anyhow::Result;
+use rsmpeg::avformat::AVFormatContextInput;
+use rsmpeg::avutil::AVDictionary;
+use rsmpeg::ffi;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+#[derive(Debug, Clone, Default)]
+pub struct LanguageRequirements {
+    pub enabled: bool,
+    pub audio: Vec<String>,
+    pub subtitles: Vec<String>,
+}
+
+impl LanguageRequirements {
+    pub fn is_effective(&self) -> bool {
+        self.enabled && (!self.audio.is_empty() || !self.subtitles.is_empty())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageCheckReport {
+    pub present_audio: Vec<String>,
+    pub present_subtitles: Vec<String>,
+    pub missing_audio: Vec<String>,
+    pub missing_subtitles: Vec<String>,
+}
+
+impl LanguageCheckReport {
+    pub fn satisfied(&self) -> bool {
+        self.missing_audio.is_empty() && self.missing_subtitles.is_empty()
+    }
+
+    pub fn describe_missing(&self) -> String {
+        let mut parts = Vec::new();
+        if !self.missing_audio.is_empty() {
+            parts.push(format!("audio [{}]", self.missing_audio.join(", ")));
+        }
+        if !self.missing_subtitles.is_empty() {
+            parts.push(format!("subtitles [{}]", self.missing_subtitles.join(", ")));
+        }
+        parts.join("; ")
+    }
+}
+
+pub fn parse_language_list(raw: Option<&str>) -> Vec<String> {
+    raw.unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .filter_map(normalize_language_tag)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+pub fn check_file(path: &Path, requirements: &LanguageRequirements) -> Result<LanguageCheckReport> {
+    let path_cstr = path_to_cstr(path)?;
+    let ictx = AVFormatContextInput::open(path_cstr.as_c_str())?;
+    let mut audio = BTreeSet::new();
+    let mut subtitles = BTreeSet::new();
+
+    for stream in ictx.streams() {
+        let cp = stream.codecpar();
+        let language = stream
+            .metadata()
+            .as_deref()
+            .and_then(extract_language_tag_from_metadata)
+            .and_then(|tag| normalize_language_tag(&tag));
+        let Some(language) = language else {
+            continue;
+        };
+        match cp.codec_type {
+            ffi::AVMEDIA_TYPE_AUDIO => {
+                audio.insert(language);
+            }
+            ffi::AVMEDIA_TYPE_SUBTITLE => {
+                subtitles.insert(language);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(check_sets(
+        audio.into_iter().collect(),
+        subtitles.into_iter().collect(),
+        requirements,
+    ))
+}
+
+fn check_sets(
+    present_audio: Vec<String>,
+    present_subtitles: Vec<String>,
+    requirements: &LanguageRequirements,
+) -> LanguageCheckReport {
+    let audio_set = present_audio.iter().cloned().collect::<BTreeSet<_>>();
+    let subtitle_set = present_subtitles.iter().cloned().collect::<BTreeSet<_>>();
+    let missing_audio = requirements
+        .audio
+        .iter()
+        .filter(|lang| !audio_set.contains(*lang))
+        .cloned()
+        .collect();
+    let missing_subtitles = requirements
+        .subtitles
+        .iter()
+        .filter(|lang| !subtitle_set.contains(*lang))
+        .cloned()
+        .collect();
+
+    LanguageCheckReport {
+        present_audio,
+        present_subtitles,
+        missing_audio,
+        missing_subtitles,
+    }
+}
+
+fn path_to_cstr(path: &Path) -> Result<std::ffi::CString> {
+    let raw = path.to_string_lossy();
+    Ok(std::ffi::CString::new(raw.as_bytes())?)
+}
+
+fn extract_language_tag_from_metadata(dict: &AVDictionary) -> Option<String> {
+    for entry in dict.iter() {
+        if entry
+            .key()
+            .to_string_lossy()
+            .eq_ignore_ascii_case("language")
+        {
+            let value = entry.value().to_string_lossy().trim().to_string();
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+fn normalize_language_tag(input: &str) -> Option<String> {
+    let primary = input
+        .trim()
+        .to_ascii_lowercase()
+        .split(['-', '_'])
+        .next()
+        .unwrap_or("")
+        .to_string();
+    if primary.is_empty() || primary == "und" || primary == "unknown" {
+        return None;
+    }
+
+    let normalized = match primary.as_str() {
+        "en" => "eng",
+        "fr" | "fre" => "fra",
+        "es" => "spa",
+        "de" | "ger" => "deu",
+        "it" => "ita",
+        "pt" => "por",
+        "ja" => "jpn",
+        "ko" => "kor",
+        "zh" => "zho",
+        "ru" => "rus",
+        "nl" => "nld",
+        "pl" => "pol",
+        "sv" => "swe",
+        "no" | "nb" => "nor",
+        "da" => "dan",
+        "fi" => "fin",
+        "cs" => "ces",
+        "cz" | "cze" => "ces",
+        "el" | "gre" => "ell",
+        "he" => "heb",
+        "hi" => "hin",
+        "ar" => "ara",
+        "tr" => "tur",
+        "th" => "tha",
+        "vi" => "vie",
+        "id" => "ind",
+        "uk" => "ukr",
+        _ => primary.as_str(),
+    };
+
+    Some(normalized.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_language_list_normalizes_and_deduplicates() {
+        assert_eq!(
+            parse_language_list(Some("en, eng, fr-FR, spa, und, ")),
+            vec!["eng", "fra", "spa"]
+        );
+    }
+
+    #[test]
+    fn check_sets_reports_missing_required_languages() {
+        let requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".into(), "jpn".into()],
+            subtitles: vec!["eng".into(), "spa".into()],
+        };
+
+        let report = check_sets(
+            vec!["eng".into()],
+            vec!["eng".into(), "fra".into()],
+            &requirements,
+        );
+
+        assert!(!report.satisfied());
+        assert_eq!(report.missing_audio, vec!["jpn"]);
+        assert_eq!(report.missing_subtitles, vec!["spa"]);
+        assert_eq!(report.describe_missing(), "audio [jpn]; subtitles [spa]");
+    }
+}

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -258,6 +258,7 @@ fn remux_with_retagged_unknown_streams(
 
     output_ctx.write_trailer()?;
     drop(output_ctx);
+    drop(input_ctx);
     replace_with_temp(&tmp_path, path, "retagging unknown stream languages")
 }
 

--- a/src/servarr/servarr_tests.rs
+++ b/src/servarr/servarr_tests.rs
@@ -209,6 +209,7 @@ mod tests {
             desired_extension: "mp4",
             desired_suffix: "",
             language_requirements: LanguageRequirements::default(),
+            untagged_retag: UntaggedRetagOptions::default(),
             api_settings: ApiSettings::default(),
             redownload_options: RedownloadOptions::default(),
         };
@@ -244,6 +245,7 @@ mod tests {
             desired_extension: "mp4",
             desired_suffix: "",
             language_requirements: LanguageRequirements::default(),
+            untagged_retag: UntaggedRetagOptions::default(),
             api_settings: ApiSettings::default(),
             redownload_options: RedownloadOptions::default(),
         };

--- a/src/servarr/servarr_tests.rs
+++ b/src/servarr/servarr_tests.rs
@@ -208,6 +208,8 @@ mod tests {
             has_output: false,
             desired_extension: "mp4",
             desired_suffix: "",
+            language_requirements: LanguageRequirements::default(),
+            api_settings: ApiSettings::default(),
         };
 
         let prep = prepare_from_env(view).unwrap();
@@ -240,6 +242,8 @@ mod tests {
             has_output: false,
             desired_extension: "mp4",
             desired_suffix: "",
+            language_requirements: LanguageRequirements::default(),
+            api_settings: ApiSettings::default(),
         };
 
         let prep = prepare_from_env(view).unwrap();

--- a/src/servarr/servarr_tests.rs
+++ b/src/servarr/servarr_tests.rs
@@ -210,6 +210,7 @@ mod tests {
             desired_suffix: "",
             language_requirements: LanguageRequirements::default(),
             api_settings: ApiSettings::default(),
+            redownload_options: RedownloadOptions::default(),
         };
 
         let prep = prepare_from_env(view).unwrap();
@@ -244,6 +245,7 @@ mod tests {
             desired_suffix: "",
             language_requirements: LanguageRequirements::default(),
             api_settings: ApiSettings::default(),
+            redownload_options: RedownloadOptions::default(),
         };
 
         let prep = prepare_from_env(view).unwrap();

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -186,6 +186,15 @@ fn prepare_servarr(args: &Args) -> Result<IntegrationPreparation> {
         has_output: args.output_file.is_some(),
         desired_extension: &args.servarr_output_extension,
         desired_suffix: &args.servarr_output_suffix,
+        language_requirements: servarr::LanguageRequirements {
+            enabled: args.servarr_language_check,
+            audio: servarr::parse_language_list(args.required_audio_languages.as_deref()),
+            subtitles: servarr::parse_language_list(args.required_subtitle_languages.as_deref()),
+        },
+        api_settings: servarr::ApiSettings {
+            url: args.servarr_api_url.clone(),
+            api_key: args.servarr_api_key.clone(),
+        },
     };
     servarr::prepare_from_env(servarr_view)
 }

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -182,6 +182,20 @@ fn handle_probe_hw_codecs(args: &Args) -> Result<()> {
     Ok(())
 }
 
+fn parse_optional_i64_list(raw: Option<&str>) -> Result<Vec<i64>> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    raw.split([',', ';', '|', ' '])
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.parse::<i64>()
+                .with_context(|| format!("parsing Servarr audit episode id '{part}'"))
+        })
+        .collect()
+}
+
 fn run_servarr_language_audit(args: &Args) -> Result<()> {
     let requirements = servarr::LanguageRequirements {
         enabled: true,
@@ -213,6 +227,9 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
             scope: args.servarr_language_audit_scope,
             lookback_days: args.servarr_language_audit_lookback_days,
             max_searches: args.servarr_language_audit_max_searches,
+            episode_ids: parse_optional_i64_list(
+                args.servarr_language_audit_episode_ids.as_deref(),
+            )?,
         },
     )?;
     info!("Servarr language audit summary: {:?}", summary);

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -191,7 +191,15 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
     if !requirements.is_effective() {
         bail!("--servarr-language-audit requires --required-audio-languages and/or --required-subtitle-languages");
     }
-    let summary = servarr::run_sonarr_language_audit(
+    let audit_kind = if args.servarr_api_url.as_deref().is_some_and(|url| {
+        url.to_ascii_lowercase().contains("7878") || url.to_ascii_lowercase().contains("radarr")
+    }) {
+        servarr::IntegrationKind::Radarr
+    } else {
+        servarr::IntegrationKind::Sonarr
+    };
+    let summary = servarr::run_language_audit(
+        audit_kind,
         &servarr::ApiSettings {
             url: args.servarr_api_url.clone(),
             api_key: args.servarr_api_key.clone(),

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -182,6 +182,22 @@ fn handle_probe_hw_codecs(args: &Args) -> Result<()> {
     Ok(())
 }
 
+fn servarr_untagged_retag_options(args: &Args) -> servarr::UntaggedRetagOptions {
+    servarr::UntaggedRetagOptions {
+        audio_language: servarr::parse_language_list(
+            args.servarr_untagged_audio_language.as_deref(),
+        )
+        .into_iter()
+        .next(),
+        subtitle_language: servarr::parse_language_list(
+            args.servarr_untagged_subtitle_language.as_deref(),
+        )
+        .into_iter()
+        .next(),
+        dry_run: args.servarr_language_dry_run,
+    }
+}
+
 fn parse_optional_i64_list(raw: Option<&str>) -> Result<Vec<i64>> {
     let Some(raw) = raw else {
         return Ok(Vec::new());
@@ -230,6 +246,7 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
             episode_ids: parse_optional_i64_list(
                 args.servarr_language_audit_episode_ids.as_deref(),
             )?,
+            untagged_retag: servarr_untagged_retag_options(args),
         },
     )?;
     info!("Servarr language audit summary: {:?}", summary);
@@ -248,6 +265,7 @@ fn prepare_servarr(args: &Args) -> Result<IntegrationPreparation> {
             audio: servarr::parse_language_list(args.required_audio_languages.as_deref()),
             subtitles: servarr::parse_language_list(args.required_subtitle_languages.as_deref()),
         },
+        untagged_retag: servarr_untagged_retag_options(args),
         api_settings: servarr::ApiSettings {
             url: args.servarr_api_url.clone(),
             api_key: args.servarr_api_key.clone(),

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -39,6 +39,9 @@ pub(crate) fn run(mut args: Args, matches_snapshot: ArgMatches) -> Result<()> {
     if maybe_handle_probe_modes(&args)? {
         return Ok(());
     }
+    if args.servarr_language_audit {
+        return run_servarr_language_audit(&args);
+    }
 
     let servarr_preparation = prepare_servarr(&args)?;
     if let IntegrationPreparation::Skip { reason } = &servarr_preparation {
@@ -176,6 +179,34 @@ fn handle_probe_hw_codecs(args: &Args) -> Result<()> {
             print_probe_codecs(args.only_video, args.only_hw);
         }
     }
+    Ok(())
+}
+
+fn run_servarr_language_audit(args: &Args) -> Result<()> {
+    let requirements = servarr::LanguageRequirements {
+        enabled: true,
+        audio: servarr::parse_language_list(args.required_audio_languages.as_deref()),
+        subtitles: servarr::parse_language_list(args.required_subtitle_languages.as_deref()),
+    };
+    if !requirements.is_effective() {
+        bail!("--servarr-language-audit requires --required-audio-languages and/or --required-subtitle-languages");
+    }
+    let summary = servarr::run_sonarr_language_audit(
+        &servarr::ApiSettings {
+            url: args.servarr_api_url.clone(),
+            api_key: args.servarr_api_key.clone(),
+        },
+        &requirements,
+        servarr::RedownloadOptions {
+            dry_run: args.servarr_language_dry_run,
+            candidate_policy: args.servarr_language_candidate_policy,
+        },
+        servarr::AuditOptions {
+            lookback_days: args.servarr_language_audit_lookback_days,
+            max_searches: args.servarr_language_audit_max_searches,
+        },
+    )?;
+    info!("Servarr language audit summary: {:?}", summary);
     Ok(())
 }
 

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -210,6 +210,7 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
             candidate_policy: args.servarr_language_candidate_policy,
         },
         servarr::AuditOptions {
+            scope: args.servarr_language_audit_scope,
             lookback_days: args.servarr_language_audit_lookback_days,
             max_searches: args.servarr_language_audit_max_searches,
         },

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -195,6 +195,10 @@ fn prepare_servarr(args: &Args) -> Result<IntegrationPreparation> {
             url: args.servarr_api_url.clone(),
             api_key: args.servarr_api_key.clone(),
         },
+        redownload_options: servarr::RedownloadOptions {
+            dry_run: args.servarr_language_dry_run,
+            candidate_policy: args.servarr_language_candidate_policy,
+        },
     };
     servarr::prepare_from_env(servarr_view)
 }

--- a/src/transcoder/ffmpeg_diagnostics.rs
+++ b/src/transcoder/ffmpeg_diagnostics.rs
@@ -6,7 +6,7 @@ use std::{env, ffi::c_char};
 pub(crate) fn av_error_to_string(err: i32) -> String {
     let mut buf = [0 as c_char; ffi::AV_ERROR_MAX_STRING_SIZE as usize];
     unsafe {
-        if ffi::av_strerror(err, buf.as_mut_ptr(), buf.len()) == 0 {
+        if ffi::av_strerror(err, buf.as_mut_ptr().cast(), buf.len()) == 0 {
             CStr::from_ptr(buf.as_ptr()).to_string_lossy().into_owned()
         } else {
             format!("ffmpeg error {}", err)

--- a/src/types.rs
+++ b/src/types.rs
@@ -106,6 +106,33 @@ impl std::fmt::Display for ResizeBackend {
     }
 }
 
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+/// Scope of Servarr items inspected during periodic language audits.
+pub(crate) enum ServarrLanguageAuditScope {
+    /// Inspect recent import history only. This is efficient for delayed dub/sub follow-up.
+    #[default]
+    History,
+    /// Inspect the current library inventory instead of only recently imported items.
+    Inventory,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+/// Confidence policy for choosing Servarr replacement releases when language requirements are missing.
+pub(crate) enum ServarrLanguageCandidatePolicy {
+    /// Only trust explicit language/subtitle fields in Arr release metadata.
+    #[default]
+    Strict,
+    /// Trust matching Arr custom format names in addition to explicit metadata.
+    CustomFormat,
+    /// Trust custom format names and strong release-title tokens such as dual-audio or multi-subs.
+    CustomFormatOrTitle,
+    /// Use looser release-title inference. Intended for dry-run/manual review.
+    TitleGuess,
+}
+
 #[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum)]
 /// Output rendering format for probe/report commands.
 pub(crate) enum OutputFormat {

--- a/src/types.rs
+++ b/src/types.rs
@@ -106,7 +106,6 @@ impl std::fmt::Display for ResizeBackend {
     }
 }
 
-
 #[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 /// Scope of Servarr items inspected during periodic language audits.


### PR DESCRIPTION
Closes #109

This PR adds an opt-in Servarr language-guard workflow for Sonarr/Radarr Download events plus Sonarr/Radarr audit modes for delayed dub/sub upgrades: DPN inspects actual imported file audio/subtitle stream languages, records its own assessment cache, and searches Arr releases for a specific replacement candidate using a configurable confidence policy when requirements are missing. Dry-run mode reports what would happen without changing Arr state, while apply mode avoids blind searches, accepts language-upgrade candidates that Arr only rejected because the current file already meets cutoff, requires a current history item to blocklist, grabs one selected replacement release, and then marks the old bad history entry failed/blocklisted; Radarr audit mode can also force-import completed pending language upgrades that Radarr otherwise refuses as quality downgrades.

```mermaid
flowchart TD
    A[DPN starts] --> AA{--servarr-language-audit?}
    AA -- Yes --> AB[Query recent Sonarr/Radarr imports and pending queue]
    AB --> AC[Inspect episode/movie files and update DPN cache]
    AC --> AD{Missing required languages?}
    AD -- No --> AE[Skip satisfied file]
    AD -- Yes --> F[Query Arr manual release search for the episode/movie]
    AA -- No --> B{Sonarr/Radarr Download event?}
    B -- No --> Z[Normal DPN CLI/probe/convert flow]
    B -- Yes --> C[Inspect imported file streams with FFmpeg]
    C --> D[Write DPN language assessment cache]
    D --> E{Required audio/subtitle languages present?}
    E -- Yes --> Z2[Continue existing DPN conversion/replacement flow]
    E -- No --> F
    F --> G{Candidate matches configured policy?}
    G -- No --> H[Skip/record no candidate; leave current file untouched]
    G -- Yes --> R{Rejected only for existing-file/cutoff?}
    R -- Yes --> I
    R -- No --> H
    R -- Not rejected --> I{Dry run?}
    I -- Yes --> J[Report selected candidate and planned action only]
    I -- No --> K{Current history item identifiable?}
    K -- No --> L[Abort replacement; do not grab or blocklist]
    K -- Yes --> M[Grab selected release]
    M --> N[Mark old history item failed/blocklisted]
```

Example CLI dry-run:

```bash
direct_play_nice \
  --servarr-language-check \
  --servarr-language-dry-run \
  --servarr-language-candidate-policy custom-format-or-title \
  --required-audio-languages eng,jpn \
  --required-subtitle-languages eng \
  --servarr-api-url http://127.0.0.1:8989 \
  --servarr-api-key "$SONARR_API_KEY"
```

Example periodic audit:

```bash
direct_play_nice \
  --config-file /path/to/direct-play-nice-sonarr.toml \
  --servarr-language-audit \
  --servarr-language-audit-lookback-days 30 \
  --servarr-language-audit-max-searches 20 \
  --servarr-language-dry-run
```

Example config file:

```toml
servarr_language_check = true
servarr_language_audit = true
servarr_language_audit_lookback_days = 30
servarr_language_audit_max_searches = 20
required_audio_languages = "eng,jpn"
required_subtitle_languages = "eng"
servarr_api_url = "http://127.0.0.1:8989"
servarr_api_key = "..."
servarr_language_dry_run = true
servarr_language_candidate_policy = "custom-format-or-title"
```

- Candidate policies: `strict`, `custom-format`, `custom-format-or-title`, `title-guess`.
- Cache path: `DIRECT_PLAY_NICE_LANGUAGE_CACHE`, otherwise `$XDG_CACHE_HOME/direct-play-nice/servarr-language-cache.json` or `~/.cache/direct-play-nice/servarr-language-cache.json`.
- Audit mode selects Sonarr vs Radarr from `servarr_api_url` (`7878`/`radarr` => Radarr, otherwise Sonarr).
- Arr API calls use long timeouts for slow manual release searches.
- No blind `EpisodeSearch` / `MoviesSearch` fallback is used for language mismatches.
- Full CLI/config examples are documented in `docs/src/servarr.md`.

## Testing

Local vcpkg was built under `target/vcpkg` and tests were run with `VCPKG_ROOT=/tmp/direct-play-nice/target/vcpkg VCPKGRS_TRIPLET=arm64-linux`.

- `cargo fmt --check`
- `git diff --check`
- `cargo test -q servarr::api::tests` → 12 passed
- `cargo test -q servarr_language` → 3 passed
- `cargo test -q servarr_language_settings` → 2 passed
- `cargo test -q records_assessment_to_configured_cache_path` → 1 passed
- `cargo test -q --lib` → 3 passed
- `cargo test -q --bins` → 148 passed, 1 ignored

Live validation was performed against a private test Servarr environment using dry-run mode and controlled apply-mode upgrades. The validation covered event-time language checks, audit-mode checks, Sonarr language-upgrade replacement, Radarr language-upgrade replacement, and Radarr pending-download force import after a quality-hierarchy refusal. No private media titles or paths are included here.
