### PR TITLE
Fix post-merge resize benchmark

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -311,22 +311,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -x /usr/local/bin/direct_play_nice ]]; then
-            echo "missing=false" >> "$GITHUB_OUTPUT"
-            echo "bin_path=/usr/local/bin/direct_play_nice" >> "$GITHUB_OUTPUT"
-            echo "Using runner-installed /usr/local/bin/direct_play_nice"
-          elif command -v direct_play_nice >/dev/null 2>&1; then
-            echo "missing=false" >> "$GITHUB_OUTPUT"
-            echo "bin_path=$(command -v direct_play_nice)" >> "$GITHUB_OUTPUT"
-            echo "Using runner-installed direct_play_nice from PATH"
-          elif [[ -x target/release/direct_play_nice ]]; then
-            echo "missing=false" >> "$GITHUB_OUTPUT"
-            echo "bin_path=target/release/direct_play_nice" >> "$GITHUB_OUTPUT"
-            echo "Using cached target/release/direct_play_nice"
-          else
-            echo "missing=true" >> "$GITHUB_OUTPUT"
-            echo "bin_path=target/release/direct_play_nice" >> "$GITHUB_OUTPUT"
-          fi
+          echo "missing=true" >> "$GITHUB_OUTPUT"
+          echo "bin_path=target/release/direct_play_nice" >> "$GITHUB_OUTPUT"
+          echo "Building current main checkout for post-merge benchmark validation"
 
       - name: Install cargo-vcpkg
         if: steps.cached-bin.outputs.missing == 'true'

--- a/scripts/resize-tools/run_resize_benchmark.sh
+++ b/scripts/resize-tools/run_resize_benchmark.sh
@@ -45,13 +45,13 @@ if [ -n "$source_video" ]; then
 
   ffmpeg -hide_banner -y "${seek_args[@]}" -i "$source_video" \
     -vf "scale=1280:720:flags=lanczos,fps=$rate,format=yuv420p" \
-    -t "$duration" -an -c:v mpeg2video -b:v 12M "$source_high"
+    -t "$duration" -an -c:v libx264 -preset veryfast -crf 12 "$source_high"
 else
   ffmpeg -hide_banner -y \
     -f lavfi -i "testsrc2=size=1280x720:rate=$rate:duration=$duration" \
     -f lavfi -i "testsrc=size=1280x720:rate=$rate:duration=$duration" \
     -filter_complex "[0:v][1:v]blend=all_mode=overlay:all_opacity=0.25,format=yuv420p" \
-    -an -c:v mpeg2video -b:v 12M "$source_high"
+    -an -c:v libx264 -preset veryfast -crf 12 "$source_high"
 fi
 
 ffmpeg -hide_banner -y -i "$source_high" \


### PR DESCRIPTION
## Summary

- Build the current main checkout for post-merge benchmark validation instead of reusing a runner-installed binary.
- Generate the resize benchmark source as H.264 so the CUDA/NVENC resize candidate can use CUDA decode + scale_cuda.

## Validation

- bash -n scripts/resize-tools/run_resize_benchmark.sh

This fixes the failed post-merge benchmark run from PR #108, where the CUDA candidate was run against an MPEG-2 intermediate that could not use the required CUDA decode path.