### PR TITLE
Fix benchmark workflow binary build

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -393,7 +393,11 @@ jobs:
 
       - name: Build release binary
         if: steps.cached-bin.outputs.missing == 'true'
-        run: cargo build --release
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release --bin direct_play_nice
+          test -x target/release/direct_play_nice
 
       - name: Validate benchmark source file
         shell: bash
@@ -408,7 +412,12 @@ jobs:
           set -euo pipefail
           bin="${{ steps.cached-bin.outputs.bin_path }}"
           if [[ ! -x "$bin" ]]; then
+            echo "Benchmark binary missing after initial build; rebuilding current checkout."
+            cargo build --release --bin direct_play_nice
+          fi
+          if [[ ! -x "$bin" ]]; then
             echo "::error title=Missing benchmark binary::Binary is not executable: $bin"
+            find target -maxdepth 3 -type f -name 'direct_play_nice*' -ls || true
             exit 1
           fi
           "$bin" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,7 @@ jobs:
       - name: Restore vcpkg workspace (cross-branch)
         id: vcpkg-root-cache-win
         uses: actions/cache/restore@v4
+        continue-on-error: true
         with:
           path: |
             target/vcpkg/.vcpkg-root


### PR DESCRIPTION
## Summary

- Make the post-merge benchmark workflow explicitly build and validate the current checkout binary.
- Rebuild during validation if the expected binary is still missing, and print target files on failure.

This follows up PR #113, whose benchmark run still failed because the expected target/release/direct_play_nice binary was not present at validation time.