### PR TITLE
Fix benchmark runner Rust toolchain path

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -396,6 +396,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ -x "${DPN_BENCH_CARGO_HOME:-/home/mkusper/.cargo}/bin/cargo" ]]; then
+            export CARGO_HOME="${DPN_BENCH_CARGO_HOME:-/home/mkusper/.cargo}"
+            export RUSTUP_HOME="${DPN_BENCH_RUSTUP_HOME:-/home/mkusper/.rustup}"
+          fi
           export PATH="$CARGO_HOME/bin:$PATH"
           cargo --version
           rustc --version
@@ -416,7 +420,11 @@ jobs:
           bin="${{ steps.cached-bin.outputs.bin_path }}"
           if [[ ! -x "$bin" ]]; then
             echo "Benchmark binary missing after initial build; rebuilding current checkout."
-            export PATH="$CARGO_HOME/bin:$PATH"
+          if [[ -x "${DPN_BENCH_CARGO_HOME:-/home/mkusper/.cargo}/bin/cargo" ]]; then
+            export CARGO_HOME="${DPN_BENCH_CARGO_HOME:-/home/mkusper/.cargo}"
+            export RUSTUP_HOME="${DPN_BENCH_RUSTUP_HOME:-/home/mkusper/.rustup}"
+          fi
+          export PATH="$CARGO_HOME/bin:$PATH"
             cargo build --release --bin direct_play_nice --verbose
           fi
           if [[ ! -x "$bin" ]]; then


### PR DESCRIPTION
## Summary

- Use the benchmark runner's persistent Rust toolchain when building the current checkout for post-merge benchmarks.
- Keeps the existing temp HOME defaults for other runtime paths, but switches CARGO_HOME/RUSTUP_HOME to the runner toolchain if available.

This follows up PR #116: the benchmark workflow now invokes the build, but the temp Rust home has no working cargo/rustc toolchain on the self-hosted runner.