### PR TITLE
Fix post-merge benchmark vcpkg root

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -356,6 +356,10 @@ jobs:
           CMAKE_BUILD_PARALLEL_LEVEL: 2
         run: |
           set -euo pipefail
+          if [[ -f /home/mkusper/vcpkg/.vcpkg-root && -d /home/mkusper/vcpkg/installed ]]; then
+            echo "Using runner vcpkg workspace at /home/mkusper/vcpkg; skipping cargo vcpkg build."
+            exit 0
+          fi
           if [[ -f target/vcpkg/.vcpkg-root && -d target/vcpkg/installed ]]; then
             echo "Using cached vcpkg workspace at target/vcpkg; skipping cargo vcpkg build."
             exit 0
@@ -364,15 +368,22 @@ jobs:
 
       - name: Export VCPKG_ROOT
         if: steps.cached-bin.outputs.missing == 'true'
-        run: echo "VCPKG_ROOT=$(pwd)/target/vcpkg" >> "$GITHUB_ENV"
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f /home/mkusper/vcpkg/.vcpkg-root && -d /home/mkusper/vcpkg/installed ]]; then
+            echo "VCPKG_ROOT=/home/mkusper/vcpkg" >> "$GITHUB_ENV"
+          else
+            echo "VCPKG_ROOT=$(pwd)/target/vcpkg" >> "$GITHUB_ENV"
+          fi
 
       - name: Validate VCPKG root
         if: steps.cached-bin.outputs.missing == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          if [[ ! -f target/vcpkg/.vcpkg-root ]]; then
-            echo "::warning title=Missing vcpkg workspace::target/vcpkg/.vcpkg-root not found; continuing with local toolchain/runtime."
+          if [[ ! -f "$VCPKG_ROOT/.vcpkg-root" ]]; then
+            echo "::warning title=Missing vcpkg workspace::$VCPKG_ROOT/.vcpkg-root not found; continuing with local toolchain/runtime."
           fi
 
       - name: Export LIBCLANG_PATH


### PR DESCRIPTION
## Summary

- Prefer the self-hosted benchmark runner's existing /home/mkusper/vcpkg workspace when building the current checkout binary.
- Fall back to target/vcpkg when the runner-level vcpkg workspace is not present.

This follows PR #117: cargo/rustc are now found, but the post-merge benchmark build failed because VCPKG_ROOT pointed at target/vcpkg even though the runner's usable FFmpeg/vcpkg workspace is under /home/mkusper/vcpkg.

## Validation

- bash -n scripts/resize-tools/run_resize_benchmark.sh
- git diff --check