### PR TITLE
Fix benchmark lock directories

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -569,6 +569,7 @@ jobs:
         run: |
           set -euo pipefail
           bin="${{ steps.cached-bin.outputs.bin_path }}"
+          export DIRECT_PLAY_NICE_LOCK_DIR=benchmark_artifacts/transcode/locks
           bash scripts/transcode-tools/run_transcode_benchmark.sh \
             --bin "$bin" \
             --source "${{ steps.source.outputs.path }}" \
@@ -594,6 +595,7 @@ jobs:
           set -euo pipefail
           bin="${{ steps.cached-bin.outputs.bin_path }}"
           export DPN_RESIZE_BENCH_BIN="$bin"
+          export DIRECT_PLAY_NICE_LOCK_DIR=benchmark_artifacts/resize/locks
           bash scripts/resize-tools/run_resize_benchmark.sh
 
       - name: Collect benchmark artifacts


### PR DESCRIPTION
## Summary
- set DIRECT_PLAY_NICE_LOCK_DIR for transcode and resize post-merge benchmarks
- avoids stale/unwritable /tmp lock files from previous runner users/jobs

## Validation
- parsed .github/workflows/benchmarks-manual.yml as YAML
- git diff --check

Context: #120 proved the build/runtime env is now correct; the current benchmark failure is the transcode CPU pass failing to open /tmp/direct-play-nice-slot-nv0-slot0.lock with EACCES.