### PR TITLE
Fix Maxwell OCR GPU benchmark fallback

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -515,12 +515,13 @@ jobs:
             --jobs-per-gpu 1 \
             --cuda-devices 0,1 \
             --require-gpu \
-            --ort-lib /opt/direct-play-nice/ort122-runtime/lib \
-            --env "LD_LIBRARY_PATH=/opt/direct-play-nice/cudnn9-runtime/lib:/opt/direct-play-nice/nvrtc12-runtime/lib:/opt/direct-play-nice/cuda12-runtime/lib:/opt/direct-play-nice/cudnn8-runtime/usr/lib:/opt/direct-play-nice/ort122-runtime/lib:/opt/direct-play-nice/ort116-runtime/lib:/opt/cuda/lib64:/usr/lib:${LD_LIBRARY_PATH:-}" \
+            --ort-lib /opt/direct-play-nice/ort116-runtime/lib \
+            --env "LD_LIBRARY_PATH=/opt/direct-play-nice/cudnn8-runtime/usr/lib:/opt/direct-play-nice/cudnn9-runtime/lib:/opt/direct-play-nice/nvrtc12-runtime/lib:/opt/direct-play-nice/cuda12-runtime/lib:/opt/direct-play-nice/ort116-runtime/lib:/opt/direct-play-nice/ort122-runtime/lib:/opt/cuda/lib64:/usr/lib:${LD_LIBRARY_PATH:-}" \
             --env "DPN_OCR_SKIP_CLS=1" \
             --env "DPN_OCR_ALLOW_LEGACY_CUDA=1" \
             --env "DPN_OCR_FORCE_CPU=0" \
-            --env "DPN_OCR_DISABLE_CUDA_SAFETY_BRAKES=1"
+            --env "DPN_OCR_DISABLE_CUDA_SAFETY_BRAKES=0" \
+            --env "DPN_OCR_CUDA_CONV_ALGO=heuristic"
 
       - name: Validate OCR benchmark used GPU
         if: always()
@@ -550,8 +551,8 @@ jobs:
             --ocr-max-jobs 2 \
             --jobs-per-gpu 1 \
             --cuda-devices 0,1 \
-            --ort-lib /opt/direct-play-nice/ort122-runtime/lib \
-            --env "LD_LIBRARY_PATH=/opt/direct-play-nice/cudnn9-runtime/lib:/opt/direct-play-nice/nvrtc12-runtime/lib:/opt/direct-play-nice/cuda12-runtime/lib:/opt/direct-play-nice/cudnn8-runtime/usr/lib:/opt/direct-play-nice/ort122-runtime/lib:/opt/direct-play-nice/ort116-runtime/lib:/opt/cuda/lib64:/usr/lib:${LD_LIBRARY_PATH:-}" \
+            --ort-lib /opt/direct-play-nice/ort116-runtime/lib \
+            --env "LD_LIBRARY_PATH=/opt/direct-play-nice/cudnn8-runtime/usr/lib:/opt/direct-play-nice/cudnn9-runtime/lib:/opt/direct-play-nice/nvrtc12-runtime/lib:/opt/direct-play-nice/cuda12-runtime/lib:/opt/direct-play-nice/ort116-runtime/lib:/opt/direct-play-nice/ort122-runtime/lib:/opt/cuda/lib64:/usr/lib:${LD_LIBRARY_PATH:-}" \
             --env "DPN_OCR_SKIP_CLS=1" \
             --env "DPN_OCR_ALLOW_LEGACY_CUDA=1" \
             --env "DPN_OCR_FORCE_CPU=1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 
 - No changes yet.
 
+## [1.1.0-beta.1] - 2026-05-21
+
+### ⚙️ Benchmark Reliability
+
+- Restored Maxwell-compatible OCR GPU benchmark execution on the Plex benchmark
+  runner by using the conservative ORT 1.16 / cuDNN8 runtime profile.
+- Kept CUDA safety brakes enabled with heuristic convolution search so required
+  GPU OCR validation completes without falling back to CPU.
+- Added manual dispatch support for the post-merge benchmark workflow so release
+  candidates can be validated on `plex-bench` before merging.
+
+### 🧪 Validation
+
+- Validated the fixed post-merge benchmark path on `plex-bench` with GPU OCR
+  required, both CUDA devices active, CPU fallback skipped, and all bitmap
+  subtitle OCR streams emitted.
+
 ## [1.0.0-beta.1] - 2026-05-21
 
 ### 📌 1.0 Beta 1 Highlights

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "1.0.0-beta.1"
+version = "1.1.0-beta.1"
 edition = "2021"
 
 


### PR DESCRIPTION
## Summary

- restore the post-merge OCR GPU benchmark to the Maxwell-compatible ORT/cuDNN profile
- use ORT 1.16 with cuDNN8 first in `LD_LIBRARY_PATH`
- keep CUDA safety brakes enabled and force heuristic conv search for the GPU OCR benchmark attempt
- keep CPU fallback aligned to the same runtime path for diagnostic consistency

Fixes #122.

## Validation

- Parsed `.github/workflows/benchmarks-manual.yml` successfully with PyYAML.
- Needs validation on the `plex-bench` self-hosted runner using the benchmark workflow.
