### PR TITLE
fix: seed bitmap subtitle OCR canvas

### DIFF
--- a/src/subtitle_ocr/mod.rs
+++ b/src/subtitle_ocr/mod.rs
@@ -54,7 +54,10 @@ pub(crate) use fixture_eval::{evaluate_ocr_fixture_accuracy, render_ocr_fixture_
 use language::*;
 pub(crate) use muxing::{mux_text_tracks_from, remux_copy_streams};
 #[cfg(test)]
-use ocr_pipeline::{quality_fallback_thresholds, OcrQualityBaseline};
+use ocr_pipeline::{
+    apply_bitmap_subtitle_canvas_fallback, quality_fallback_thresholds, subtitle_rect_counts,
+    OcrQualityBaseline,
+};
 use text_render::*;
 
 #[cfg(test)]

--- a/src/subtitle_ocr/ocr_pipeline.rs
+++ b/src/subtitle_ocr/ocr_pipeline.rs
@@ -124,11 +124,14 @@ pub(super) fn ocr_single_stream(
     let input_cstr = CString::new(request.input_path).context("input path has interior NUL")?;
     let mut ictx = AVFormatContextInput::open(input_cstr.as_c_str())?;
 
-    let (stream_time_base, stream_codec_id) = ictx
+    let (stream_time_base, stream_codec_id, stream_width, stream_height) = ictx
         .streams()
         .iter()
         .find(|st| st.index == request.stream_index)
-        .map(|st| (st.time_base, st.codecpar().codec_id))
+        .map(|st| {
+            let cp = st.codecpar();
+            (st.time_base, cp.codec_id, cp.width, cp.height)
+        })
         .ok_or_else(|| anyhow!("subtitle stream {} not found", request.stream_index))?;
 
     let decoder = AVCodec::find_decoder(stream_codec_id).ok_or_else(|| {
@@ -155,10 +158,22 @@ pub(super) fn ocr_single_stream(
         );
     }
     decode_context.set_time_base(stream_time_base);
+    apply_bitmap_subtitle_canvas_fallback(
+        &mut decode_context,
+        stream_codec_id,
+        stream_width,
+        stream_height,
+        request.video_dimensions,
+        request.stream_index,
+    );
     decode_context.open(None)?;
 
     let mut cues = Vec::new();
     let mut packet_seq: usize = 0;
+    let mut subtitle_packet_count: usize = 0;
+    let mut decoded_subtitle_count: usize = 0;
+    let mut decoded_rect_count: usize = 0;
+    let mut decoded_image_rect_count: usize = 0;
     let mut quality_baseline = OcrQualityBaseline::default();
 
     loop {
@@ -170,6 +185,7 @@ pub(super) fn ocr_single_stream(
         if packet.stream_index != request.stream_index {
             continue;
         }
+        subtitle_packet_count += 1;
 
         let src_pts = packet.pts;
         let src_dur = packet.duration;
@@ -177,6 +193,10 @@ pub(super) fn ocr_single_stream(
         packet.rescale_ts(stream_time_base, decode_context.time_base);
 
         if let Some(subtitle) = decode_context.decode_subtitle(Some(&mut packet))? {
+            decoded_subtitle_count += 1;
+            let (rect_count, image_rect_count) = subtitle_rect_counts(subtitle.as_ptr());
+            decoded_rect_count += rect_count;
+            decoded_image_rect_count += image_rect_count;
             let fallback_start_ms = timestamp_to_ms(src_pts, stream_time_base).unwrap_or(0);
             let fallback_dur_ms = timestamp_to_ms(src_dur, stream_time_base)
                 .unwrap_or(0)
@@ -207,6 +227,10 @@ pub(super) fn ocr_single_stream(
         let Some(subtitle) = decode_context.decode_subtitle(None)? else {
             break;
         };
+        decoded_subtitle_count += 1;
+        let (rect_count, image_rect_count) = subtitle_rect_counts(subtitle.as_ptr());
+        decoded_rect_count += rect_count;
+        decoded_image_rect_count += image_rect_count;
         let cue_params = CueBuildParams {
             language: request.language,
             stream_index: request.stream_index,
@@ -230,7 +254,89 @@ pub(super) fn ocr_single_stream(
 
     sanitize_cues(&mut cues, request.ocr_format);
 
+    if cues.is_empty() && subtitle_packet_count > 0 && is_image_based_subtitle(stream_codec_id) {
+        bail!(
+            "OCR produced no cues for bitmap subtitle stream {} ({}) despite reading {} subtitle packet(s); decoded_subtitles={}, decoded_rects={}, decoded_image_rects={}, video_dimensions={:?}. This usually means the bitmap subtitle decoder could not derive a valid canvas/rectangle layout.",
+            request.stream_index,
+            codec_name(stream_codec_id),
+            subtitle_packet_count,
+            decoded_subtitle_count,
+            decoded_rect_count,
+            decoded_image_rect_count,
+            request.video_dimensions
+        );
+    }
+
     Ok(cues)
+}
+
+pub(super) fn apply_bitmap_subtitle_canvas_fallback(
+    decode_context: &mut AVCodecContext,
+    codec_id: ffi::AVCodecID,
+    stream_width: i32,
+    stream_height: i32,
+    video_dimensions: Option<(u32, u32)>,
+    stream_index: i32,
+) {
+    if !is_image_based_subtitle(codec_id) {
+        return;
+    }
+    if decode_context.width > 0 && decode_context.height > 0 {
+        return;
+    }
+
+    let Some((video_width, video_height)) = video_dimensions else {
+        return;
+    };
+    if video_width == 0 || video_height == 0 {
+        return;
+    }
+
+    let width = stream_width.max(video_width as i32);
+    let height = stream_height.max(video_height as i32);
+    if width <= 0 || height <= 0 {
+        return;
+    }
+
+    unsafe {
+        let ctx = decode_context.as_mut_ptr();
+        (*ctx).width = width;
+        (*ctx).height = height;
+        (*ctx).coded_width = width;
+        (*ctx).coded_height = height;
+    }
+    info!(
+        "Applying bitmap subtitle canvas fallback for stream {} ({}): {}x{} from video dimensions {:?}",
+        stream_index,
+        codec_name(codec_id),
+        width,
+        height,
+        video_dimensions
+    );
+}
+
+pub(super) fn subtitle_rect_counts(subtitle: *const ffi::AVSubtitle) -> (usize, usize) {
+    if subtitle.is_null() {
+        return (0, 0);
+    }
+    let sub = unsafe { &*subtitle };
+    if sub.num_rects == 0 || sub.rects.is_null() {
+        return (0, 0);
+    }
+
+    let mut image_rects = 0usize;
+    for i in 0..sub.num_rects {
+        let rect_ptr = unsafe { *sub.rects.add(i as usize) };
+        if rect_ptr.is_null() {
+            continue;
+        }
+        let rect = unsafe { &*rect_ptr };
+        if rect.type_ == ffi::SUBTITLE_BITMAP {
+            image_rects += 1;
+        }
+    }
+
+    (sub.num_rects as usize, image_rects)
 }
 
 fn subtitle_to_cues(

--- a/src/subtitle_ocr/tests.rs
+++ b/src/subtitle_ocr/tests.rs
@@ -66,6 +66,80 @@ fn char_error_rate(expected: &str, actual: &str) -> f32 {
 }
 
 #[test]
+fn bitmap_subtitle_canvas_fallback_uses_video_dimensions_when_decoder_has_no_size() {
+    let decoder = AVCodec::find_decoder(ffi::AV_CODEC_ID_HDMV_PGS_SUBTITLE)
+        .expect("PGS decoder should be available in FFmpeg build");
+    let mut ctx = AVCodecContext::new(&decoder);
+
+    apply_bitmap_subtitle_canvas_fallback(
+        &mut ctx,
+        ffi::AV_CODEC_ID_HDMV_PGS_SUBTITLE,
+        0,
+        0,
+        Some((1440, 1080)),
+        3,
+    );
+
+    assert_eq!(ctx.width, 1440);
+    assert_eq!(ctx.height, 1080);
+    assert_eq!(ctx.coded_width, 1440);
+    assert_eq!(ctx.coded_height, 1080);
+}
+
+#[test]
+fn bitmap_subtitle_canvas_fallback_preserves_existing_decoder_size() {
+    let decoder = AVCodec::find_decoder(ffi::AV_CODEC_ID_HDMV_PGS_SUBTITLE)
+        .expect("PGS decoder should be available in FFmpeg build");
+    let mut ctx = AVCodecContext::new(&decoder);
+    unsafe {
+        (*ctx.as_mut_ptr()).width = 1920;
+        (*ctx.as_mut_ptr()).height = 1080;
+        (*ctx.as_mut_ptr()).coded_width = 1920;
+        (*ctx.as_mut_ptr()).coded_height = 1080;
+    }
+
+    apply_bitmap_subtitle_canvas_fallback(
+        &mut ctx,
+        ffi::AV_CODEC_ID_HDMV_PGS_SUBTITLE,
+        0,
+        0,
+        Some((1440, 1080)),
+        3,
+    );
+
+    assert_eq!(ctx.width, 1920);
+    assert_eq!(ctx.height, 1080);
+    assert_eq!(ctx.coded_width, 1920);
+    assert_eq!(ctx.coded_height, 1080);
+}
+
+#[test]
+fn bitmap_subtitle_canvas_fallback_uses_larger_stream_dimensions() {
+    let decoder = AVCodec::find_decoder(ffi::AV_CODEC_ID_HDMV_PGS_SUBTITLE)
+        .expect("PGS decoder should be available in FFmpeg build");
+    let mut ctx = AVCodecContext::new(&decoder);
+
+    apply_bitmap_subtitle_canvas_fallback(
+        &mut ctx,
+        ffi::AV_CODEC_ID_HDMV_PGS_SUBTITLE,
+        1920,
+        1080,
+        Some((1440, 1080)),
+        3,
+    );
+
+    assert_eq!(ctx.width, 1920);
+    assert_eq!(ctx.height, 1080);
+    assert_eq!(ctx.coded_width, 1920);
+    assert_eq!(ctx.coded_height, 1080);
+}
+
+#[test]
+fn subtitle_rect_counts_handles_null_subtitle() {
+    assert_eq!(subtitle_rect_counts(std::ptr::null()), (0, 0));
+}
+
+#[test]
 fn external_ocr_command_parser_requires_program_name() {
     assert!(parse_external_ocr_argv("").is_err());
     assert!(parse_external_ocr_argv("   ").is_err());


### PR DESCRIPTION
## Summary
- seed bitmap subtitle decoder canvas dimensions from the video stream when subtitle codec parameters omit width/height
- fail loudly when a bitmap subtitle stream has packets but OCR produces no cues, including packet/rect diagnostics
- add unit coverage for PGS canvas seeding and no-rect accounting

## Why
The sample S00E03 PGS track has 340 PGS packets, but FFmpeg initially reports the stream as `hdmv_pgs_subtitle` with unspecified size. The current OCR path copies those zero dimensions into the subtitle decoder and never supplies the equivalent of FFmpeg CLI `-canvas_size`, so the decoder can produce no usable subtitle rectangles and the stream is silently skipped.

This makes the primary OCR path less brittle: image subtitle decoding should get a valid canvas before OCR/fallback logic is even considered. Fallbacks can still handle OCR quality, but the default path needs to reliably produce subtitle bitmaps first.

## Validation
- `cargo fmt --check`
- Plex repro on release `v1.1.0-beta.2` still fails on the S00E03 sample:
  - PGS stream has 340 packets / 340 frames
  - `OCR worker plan ... gpu_available=true`
  - `Skipping OCR subtitle stream 3 because OCR produced no cues`
- Root-cause confirmation on the same sample:
  - FFmpeg reports the PGS stream as `1440x1080` when the equivalent canvas is supplied
  - a repo benchmark binary with a working canvas decode path produced 171 OCR cues and an English `mov_text` stream
  - extracted SRT metrics from that successful decode: `lines=180`, `space_rate=0.197`, `long=0`, `max=11`

Full compile/test should be verified by CI. Local full `cargo check` in this aarch64 Coder workspace is blocked by its existing local vcpkg/rusty_ffmpeg linkage mismatch (`Link vcpkg FFmpeg failed: NotMSVC`). The plexserver rustup toolchain also resolves incompatible FFmpeg bindings outside the repo's cached build path, so I did not overwrite the installed binary with this patch.
