### PR TITLE
Fix Servarr skip for direct-play-compatible files

### DIFF
--- a/src/main_sidecar.rs
+++ b/src/main_sidecar.rs
@@ -22,7 +22,7 @@ pub(super) struct OcrSidecarRequest<'a> {
     pub(super) ocr_write_srt_sidecar: bool,
 }
 
-pub(super) fn post_process_ocr_subtitles(request: OcrSidecarRequest<'_>) -> Result<()> {
+pub(super) fn post_process_ocr_subtitles(request: OcrSidecarRequest<'_>) -> Result<bool> {
     let OcrSidecarRequest {
         input_file,
         mux_source_file,
@@ -36,7 +36,7 @@ pub(super) fn post_process_ocr_subtitles(request: OcrSidecarRequest<'_>) -> Resu
     } = request;
 
     if matches!(sub_mode, SubMode::Skip) {
-        return Ok(());
+        return Ok(false);
     }
 
     let ocr_work_dir = OcrWorkDir::create()?;
@@ -50,10 +50,15 @@ pub(super) fn post_process_ocr_subtitles(request: OcrSidecarRequest<'_>) -> Resu
         ocr_format,
         ocr_external_command,
     )?;
+    if tracks.is_empty() {
+        info!("No bitmap subtitle tracks required OCR; no OCR mux output was produced.");
+        return Ok(false);
+    }
+
     subtitle_ocr::mux_text_tracks_from(mux_source_file, output_file, &tracks)?;
     write_ocr_srt_sidecars(output_file, &tracks, ocr_write_srt_sidecar)?;
 
-    Ok(())
+    Ok(true)
 }
 
 struct OcrWorkDir {

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -672,6 +672,8 @@ fn run_conversion(
         }
     }
 
+    let mut output_ready = conversion_result.is_ok() && needs_conversion && !output_is_mkv;
+
     if conversion_result.is_ok() && should_ocr {
         let mux_source_file = if needs_conversion {
             conversion_output_file
@@ -679,7 +681,7 @@ fn run_conversion(
             input_file
         };
         conversion_result = conversion_result.and_then(|outcome| {
-            post_process_ocr_subtitles(OcrSidecarRequest {
+            let ocr_output_ready = post_process_ocr_subtitles(OcrSidecarRequest {
                 input_file,
                 mux_source_file,
                 output_file,
@@ -690,13 +692,19 @@ fn run_conversion(
                 ocr_external_command: args.ocr_external_command.as_deref(),
                 ocr_write_srt_sidecar: args.ocr_write_srt_sidecar,
             })?;
+            output_ready = output_ready || ocr_output_ready;
             Ok(outcome)
         });
+        if conversion_result.is_ok() && !output_ready && needs_conversion && output_is_mkv {
+            subtitle_ocr::remux_copy_streams(conversion_output_file, output_file)?;
+            output_ready = true;
+        }
     } else if conversion_result.is_ok() && needs_conversion && output_is_mkv {
         subtitle_ocr::remux_copy_streams(conversion_output_file, output_file)?;
+        output_ready = true;
     }
 
-    if conversion_result.is_ok() && args.validate_output {
+    if conversion_result.is_ok() && output_ready && args.validate_output {
         if let Err(err) = validate_output_file(output_file, target_video_codec, common_audio_codec)
         {
             conversion_result = Err(err);
@@ -713,6 +721,14 @@ fn run_conversion(
     match (plan, conversion_result) {
         (Some(plan), Ok(outcome)) => {
             debug_assert!(outcome.profile_verified());
+            if !output_ready {
+                info!(
+                    "No output was produced for {:?} integration because the input was already compatible; leaving source file '{}' untouched.",
+                    plan.kind,
+                    plan.input_path.display()
+                );
+                return Ok(());
+            }
             let final_path = plan.finalize_success()?;
             if let Some(ref refresher) = plex_refresher {
                 if let Err(err) = refresher.refresh_path(&final_path) {
@@ -735,7 +751,7 @@ fn run_conversion(
             Err(err)
         }
         (None, Ok(outcome)) => {
-            if args.delete_source.unwrap_or(false) {
+            if args.delete_source.unwrap_or(false) && output_ready {
                 if !outcome.profile_verified() {
                     warn!(
                         "Skipping --delete-source because profile/level verification did not confirm expected constraints"
@@ -764,15 +780,17 @@ fn run_conversion(
                     }
                 }
             }
-            if let Some(ref refresher) = plex_refresher {
-                if let Some(output_cstr) = args.output_file.as_ref() {
-                    let output_path = cstr_to_path_buf(output_cstr);
-                    if let Err(err) = refresher.refresh_path(&output_path) {
-                        warn!(
-                            "Plex refresh failed for '{}': {}",
-                            output_path.display(),
-                            err
-                        );
+            if output_ready {
+                if let Some(ref refresher) = plex_refresher {
+                    if let Some(output_cstr) = args.output_file.as_ref() {
+                        let output_path = cstr_to_path_buf(output_cstr);
+                        if let Err(err) = refresher.refresh_path(&output_path) {
+                            warn!(
+                                "Plex refresh failed for '{}': {}",
+                                output_path.display(),
+                                err
+                            );
+                        }
                     }
                 }
             }

--- a/tests/cli_servarr.rs
+++ b/tests/cli_servarr.rs
@@ -28,6 +28,53 @@ fn append_suffix(path: &Path, suffix: &str) -> PathBuf {
     }
 }
 
+fn gen_direct_play_mp4(path: &Path) {
+    assert!(
+        Command::new("ffmpeg")
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=640x360:rate=30:duration=2",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:sample_rate=48000:duration=2",
+                "-c:v",
+                "libx264",
+                "-b:v",
+                "700k",
+                "-minrate",
+                "700k",
+                "-maxrate",
+                "700k",
+                "-bufsize",
+                "1400k",
+                "-profile:v",
+                "high",
+                "-level:v",
+                "4.1",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "96k",
+                "-movflags",
+                "+faststart",
+                path.to_string_lossy().as_ref(),
+            ])
+            .status()
+            .expect("invoke ffmpeg")
+            .success(),
+        "ffmpeg failed to generate direct-play sample"
+    );
+}
+
 #[test]
 fn sonarr_test_event_short_circuits() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = TempDir::new()?;
@@ -66,6 +113,72 @@ fn sonarr_grab_event_skips_conversion() -> Result<(), Box<dyn std::error::Error>
     assert!(
         !backup_path.exists(),
         "no backup file should be produced for Grab events"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn sonarr_download_skips_already_direct_play_without_replacement(
+) -> Result<(), Box<dyn std::error::Error>> {
+    common::ensure_ffmpeg_present();
+
+    let tmp = TempDir::new()?;
+    let input = tmp.path().join("already_direct_play.mp4");
+    gen_direct_play_mp4(&input);
+
+    let final_path = input.with_file_name("already_direct_play.fixed.mp4");
+    let temp_path = append_suffix(&final_path, ".direct-play-nice.tmp");
+    let backup_path = append_suffix(&input, ".direct-play-nice.bak");
+
+    let config_path = tmp.path().join("direct-play-nice.toml");
+    fs::write(&config_path, "")?;
+
+    let lock_dir = tmp.path().join("locks");
+    fs::create_dir_all(&lock_dir)?;
+
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("direct_play_nice"))
+        .env("DIRECT_PLAY_NICE_LOCK_DIR", &lock_dir)
+        .env("sonarr_eventtype", "Download")
+        .env("sonarr_episodefile_path", &input)
+        .env("sonarr_series_title", "Compat Test")
+        .arg("--config-file")
+        .arg(&config_path)
+        .arg("-s")
+        .arg("chromecast_1st_gen,chromecast_2nd_gen,chromecast_ultra")
+        .arg("--video-quality")
+        .arg("480p")
+        .arg("--audio-quality")
+        .arg("128k")
+        .arg("--max-video-bitrate")
+        .arg("1M")
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "expected already-compatible Sonarr file to be skipped successfully; stderr:
+{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Input is direct-play compatible"),
+        "stderr did not include direct-play skip message:
+{stderr}"
+    );
+
+    assert!(input.exists(), "original file should remain in place");
+    assert!(
+        !final_path.exists(),
+        "skip path should not promote a replacement output"
+    );
+    assert!(
+        !temp_path.exists(),
+        "skip path should not leave a temporary output"
+    );
+    assert!(
+        !backup_path.exists(),
+        "skip path should not create a source backup"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- Track whether conversion/OCR actually produced an output before finalizing Servarr replacement plans.
- Have OCR post-processing report `false` when there are no bitmap subtitle tracks, so already-compatible files can be left untouched.
- Add a Sonarr regression test for an already direct-play-compatible MP4 that should not create a temp, final, or backup file.

Resolves #35.

## Context
While confirming whether direct-play skip behavior worked, I reproduced a Servarr failure on `plexserver`: compatible MP4 inputs still entered the OCR path because MP4 output requests OCR handling, no OCR tracks were generated, and the integration then tried to promote a non-existent temp output. This change treats that as a successful skip instead of a replacement.

## Testing
- `cargo fmt --all -- --check`
- Reproduced the pre-fix failure on `plexserver` with installed `/usr/local/bin/direct_play_nice` 1.1.0-beta.2.
- Build/test execution is blocked in the current environments by FFmpeg/vcpkg dependency setup:
  - local: `cargo test --no-run --test cli_servarr --features ffmpeg-cli-tests` fails in `rusty_ffmpeg` build with `Link vcpkg FFmpeg failed: NotMSVC`.
  - `plexserver`: after `cargo vcpkg build`, `cargo +stable test --no-run --test cli_servarr --features ffmpeg-cli-tests` fails while compiling `rsmpeg` against generated FFmpeg bindings.
