### PR TITLE
Fix Servarr filename quality tags

### DIFF
--- a/src/servarr.rs
+++ b/src/servarr.rs
@@ -1,5 +1,6 @@
 //! Sonarr/Radarr integration workflow for event handling, path planning, and atomic media replacement.
 
+use crate::transcoder::VideoQuality;
 use anyhow::{bail, Context, Result};
 use log::{info, warn};
 use std::env;
@@ -217,6 +218,7 @@ pub struct ArgsView<'a> {
     pub has_output: bool,
     pub desired_extension: &'a str,
     pub desired_suffix: &'a str,
+    pub desired_video_quality: VideoQuality,
     pub language_requirements: LanguageRequirements,
     pub untagged_retag: language::UntaggedRetagOptions,
     pub api_settings: ApiSettings,
@@ -437,8 +439,12 @@ fn prepare_download(
             );
         }
 
-        let final_output_path =
-            resolve_output_path(&input_path, view.desired_extension, effective_suffix)?;
+        let final_output_path = resolve_output_path(
+            &input_path,
+            view.desired_extension,
+            effective_suffix,
+            view.desired_video_quality,
+        )?;
         let temp_output_path = append_suffix(&final_output_path, ".direct-play-nice.tmp");
         let backup_path = append_suffix(&input_path, ".direct-play-nice.bak");
 
@@ -472,8 +478,14 @@ fn resolve_output_path(
     input_path: &Path,
     desired_ext: &str,
     desired_suffix: &str,
+    desired_video_quality: VideoQuality,
 ) -> Result<PathBuf> {
-    path_policy::resolve_output_path(input_path, desired_ext, desired_suffix)
+    path_policy::resolve_output_path(
+        input_path,
+        desired_ext,
+        desired_suffix,
+        desired_video_quality,
+    )
 }
 
 fn append_suffix(path: &Path, suffix: &str) -> PathBuf {

--- a/src/servarr/path_policy.rs
+++ b/src/servarr/path_policy.rs
@@ -90,11 +90,11 @@ fn update_filename_quality(stem: &str, desired_video_quality: VideoQuality) -> S
             let before_ok = stem[..start]
                 .chars()
                 .next_back()
-                .map_or(true, |ch| !ch.is_ascii_alphanumeric());
+                .is_none_or(|ch| !ch.is_ascii_alphanumeric());
             let after_ok = stem[p_idx + 1..]
                 .chars()
                 .next()
-                .map_or(true, |ch| !ch.is_ascii_alphanumeric());
+                .is_none_or(|ch| !ch.is_ascii_alphanumeric());
 
             if is_known_quality && before_ok && after_ok {
                 last_match = Some((start, p_idx + 1));

--- a/src/servarr/path_policy.rs
+++ b/src/servarr/path_policy.rs
@@ -1,5 +1,6 @@
 //! Output path-policy rules that apply extension and suffix transformations for replacement outputs.
 
+use crate::transcoder::VideoQuality;
 use anyhow::{anyhow, bail, Context, Result};
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
@@ -9,6 +10,7 @@ pub(super) fn resolve_output_path(
     input_path: &Path,
     desired_ext: &str,
     desired_suffix: &str,
+    desired_video_quality: VideoQuality,
 ) -> Result<PathBuf> {
     let parent = input_path.parent();
     let stem = input_path
@@ -42,7 +44,7 @@ pub(super) fn resolve_output_path(
         trimmed.to_string()
     };
 
-    let mut filename = String::from(stem);
+    let mut filename = update_filename_quality(stem, desired_video_quality);
     if let Some(sfx) = suffix.as_ref() {
         filename.push_str(sfx);
     }
@@ -57,6 +59,59 @@ pub(super) fn resolve_output_path(
     };
 
     Ok(new_path)
+}
+
+fn update_filename_quality(stem: &str, desired_video_quality: VideoQuality) -> String {
+    let target = match desired_video_quality {
+        VideoQuality::MatchSource => return stem.to_string(),
+        quality => quality.to_string(),
+    };
+
+    let mut replaced = String::with_capacity(stem.len());
+    let mut search_start = 0;
+    let mut last_match = None;
+
+    while let Some((relative_start, _)) = stem[search_start..]
+        .char_indices()
+        .find(|(_, ch)| matches!(ch, 'p' | 'P'))
+    {
+        let p_idx = search_start + relative_start;
+        let digit_start = stem[..p_idx]
+            .char_indices()
+            .rev()
+            .take_while(|(_, ch)| ch.is_ascii_digit())
+            .last()
+            .map(|(idx, _)| idx);
+
+        if let Some(start) = digit_start {
+            let digits = &stem[start..p_idx];
+            let is_known_quality =
+                matches!(digits, "360" | "480" | "720" | "1080" | "1440" | "2160");
+            let before_ok = stem[..start]
+                .chars()
+                .next_back()
+                .map_or(true, |ch| !ch.is_ascii_alphanumeric());
+            let after_ok = stem[p_idx + 1..]
+                .chars()
+                .next()
+                .map_or(true, |ch| !ch.is_ascii_alphanumeric());
+
+            if is_known_quality && before_ok && after_ok {
+                last_match = Some((start, p_idx + 1));
+            }
+        }
+
+        search_start = p_idx + 'p'.len_utf8();
+    }
+
+    if let Some((start, end)) = last_match {
+        replaced.push_str(&stem[..start]);
+        replaced.push_str(&target);
+        replaced.push_str(&stem[end..]);
+        replaced
+    } else {
+        stem.to_string()
+    }
 }
 
 /// Normalizes a suffix value to either `None` or a dot-prefixed string.

--- a/src/servarr/servarr_tests.rs
+++ b/src/servarr/servarr_tests.rs
@@ -3,6 +3,7 @@
 #[cfg(test)]
 mod tests {
     use crate::servarr::*;
+    use crate::transcoder::VideoQuality;
     use std::ffi::CString;
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -19,29 +20,57 @@ mod tests {
     #[test]
     fn resolve_output_path_match_input() {
         let base = PathBuf::from("Movie.mkv");
-        let resolved = resolve_output_path(&base, "match-input", "").unwrap();
+        let resolved =
+            resolve_output_path(&base, "match-input", "", VideoQuality::MatchSource).unwrap();
         assert_eq!(resolved, base);
     }
 
     #[test]
     fn resolve_output_path_custom_extension() {
         let base = PathBuf::from("Movie.mkv");
-        let resolved = resolve_output_path(&base, "mp4", "").unwrap();
+        let resolved = resolve_output_path(&base, "mp4", "", VideoQuality::MatchSource).unwrap();
         assert_eq!(resolved, PathBuf::from("Movie.mp4"));
     }
 
     #[test]
     fn resolve_output_path_with_suffix_and_extension() {
         let base = PathBuf::from("Movie.mkv");
-        let resolved = resolve_output_path(&base, "mp4", ".fixed").unwrap();
+        let resolved =
+            resolve_output_path(&base, "mp4", ".fixed", VideoQuality::MatchSource).unwrap();
         assert_eq!(resolved, PathBuf::from("Movie.fixed.mp4"));
     }
 
     #[test]
     fn resolve_output_path_with_suffix_and_match_input() {
         let base = PathBuf::from("Episode.mkv");
-        let resolved = resolve_output_path(&base, "match-input", "fixed").unwrap();
+        let resolved =
+            resolve_output_path(&base, "match-input", "fixed", VideoQuality::MatchSource).unwrap();
         assert_eq!(resolved, PathBuf::from("Episode.fixed.mkv"));
+    }
+
+    #[test]
+    fn resolve_output_path_updates_filename_quality() {
+        let base = PathBuf::from("Show.S01E01.1080p.WEB-DL.mkv");
+        let resolved = resolve_output_path(&base, "mp4", ".fixed", VideoQuality::P720).unwrap();
+        assert_eq!(resolved, PathBuf::from("Show.S01E01.720p.WEB-DL.fixed.mp4"));
+    }
+
+    #[test]
+    fn resolve_output_path_updates_uppercase_filename_quality() {
+        let base = PathBuf::from("Show.S01E01.1080P.WEB-DL.mkv");
+        let resolved = resolve_output_path(&base, "mp4", ".fixed", VideoQuality::P720).unwrap();
+        assert_eq!(resolved, PathBuf::from("Show.S01E01.720p.WEB-DL.fixed.mp4"));
+    }
+
+    #[test]
+    fn resolve_output_path_preserves_filename_quality_for_match_source() {
+        let base = PathBuf::from("Show.S01E01.1080p.WEB-DL.mkv");
+        let resolved =
+            resolve_output_path(&base, "mp4", ".fixed", VideoQuality::MatchSource).unwrap();
+        assert_eq!(
+            resolved,
+            PathBuf::from("Show.S01E01.1080p.WEB-DL.fixed.mp4")
+        );
     }
 
     #[test]
@@ -208,6 +237,7 @@ mod tests {
             has_output: false,
             desired_extension: "mp4",
             desired_suffix: "",
+            desired_video_quality: VideoQuality::MatchSource,
             language_requirements: LanguageRequirements::default(),
             untagged_retag: UntaggedRetagOptions::default(),
             api_settings: ApiSettings::default(),
@@ -244,6 +274,7 @@ mod tests {
             has_output: false,
             desired_extension: "mp4",
             desired_suffix: "",
+            desired_video_quality: VideoQuality::MatchSource,
             language_requirements: LanguageRequirements::default(),
             untagged_retag: UntaggedRetagOptions::default(),
             api_settings: ApiSettings::default(),

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -260,6 +260,7 @@ fn prepare_servarr(args: &Args) -> Result<IntegrationPreparation> {
         has_output: args.output_file.is_some(),
         desired_extension: &args.servarr_output_extension,
         desired_suffix: &args.servarr_output_suffix,
+        desired_video_quality: args.video_quality,
         language_requirements: servarr::LanguageRequirements {
             enabled: args.servarr_language_check,
             audio: servarr::parse_language_list(args.required_audio_languages.as_deref()),


### PR DESCRIPTION
Closes #48.

## Summary
- update Servarr replacement output names to swap existing resolution tags like `1080p`/`1080P` to the requested `--video-quality` label
- preserve filenames unchanged when video quality is `match-source`
- add path-policy regression coverage

## Tests
- `env VCPKG_ROOT=/workspace/target/vcpkg VCPKGRS_TRIPLET=arm64-linux VCPKG_BUILD_TYPE=release PKG_CONFIG_PATH=/workspace/target/vcpkg/installed/arm64-linux/lib/pkgconfig FFMPEG_PKG_CONFIG_PATH=/workspace/target/vcpkg/installed/arm64-linux/lib/pkgconfig cargo test resolve_output_path --no-default-features`
