### PR TITLE
chore(release): v1.1.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.1.0-beta.3] - 2026-06-01
 
-### 🛠️ Fixed
+### 🛠️ Beta 3 Fixes
 
 - Fixed bitmap-subtitle OCR canvas seeding so bitmap subtitles render more
   reliably before OCR.
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 - Fixed Servarr output filename quality tags to reflect the requested output
   quality instead of stale or source quality metadata.
 
-### 🧪 Validation
+### 🧪 Beta 3 Validation
 
 - Added regression coverage for subtitle encode overflow and unsupported
   subtitle-character handling, covering both skip-stream completion and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0-beta.3] - 2026-06-01
+
+### 🛠️ Fixed
+
+- Fixed bitmap-subtitle OCR canvas seeding so bitmap subtitles render more
+  reliably before OCR.
+- Fixed Servarr handling for direct-play-compatible files so already-compatible
+  imports are detected and skipped correctly.
+- Fixed Servarr output filename quality tags to reflect the requested output
+  quality instead of stale or source quality metadata.
+
+### 🧪 Validation
+
+- Added regression coverage for subtitle encode overflow and unsupported
+  subtitle-character handling, covering both skip-stream completion and
+  fail-policy failure behavior.
+- Validated post-merge GPU OCR, spacing regression, NVENC transcode, and resize
+  benchmark results before cutting this release candidate.
+
 ## [1.1.0-beta.2] - 2026-05-27
 
 ### 🛠️ Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 edition = "2021"
 
 


### PR DESCRIPTION
## Summary
- Bump crate version to `1.1.0-beta.3`.
- Add concrete `CHANGELOG.md` release notes for `v1.1.0-beta.3`.
- Summarize fixes for bitmap subtitle OCR canvas seeding, Servarr direct-play skips, Servarr filename quality tags, and subtitle encode-overflow regression coverage.

## Validation
- `bash scripts/validate_release_changelog.sh`
- `cargo fmt --check`
- `git diff --check`
