### PR TITLE
Fix Servarr history lookback pagination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "**"
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -15,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.body, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.body, '[skip ci]')) }}
     name: Test (Linux) (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     env:

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -16,6 +16,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 use ureq::{Agent, AgentBuilder};
 
+const SERVARR_HISTORY_PAGE_SIZE: u32 = 100;
+const SERVARR_HISTORY_MAX_PAGES: u32 = 1_000;
+
 #[derive(Debug, Clone, Default)]
 pub struct ApiSettings {
     pub url: Option<String>,
@@ -522,9 +525,9 @@ impl ApiClient {
     fn sonarr_recent_import_history(&self, lookback_days: u32) -> Result<Vec<Value>> {
         let mut out = Vec::new();
         let min_day = current_day_number().saturating_sub(lookback_days as i64);
-        for page in 1..=10 {
+        for page in 1..=SERVARR_HISTORY_MAX_PAGES {
             let endpoint = format!(
-                "{}/api/v3/history?page={page}&pageSize=100&sortKey=date&sortDirection=descending&includeSeries=true&includeEpisode=true",
+                "{}/api/v3/history?page={page}&pageSize={SERVARR_HISTORY_PAGE_SIZE}&sortKey=date&sortDirection=descending&includeSeries=true&includeEpisode=true",
                 self.base_url
             );
             let response = self.get(&endpoint)?;
@@ -712,9 +715,9 @@ impl ApiClient {
     fn radarr_recent_import_history(&self, lookback_days: u32) -> Result<Vec<Value>> {
         let mut out = Vec::new();
         let min_day = current_day_number().saturating_sub(lookback_days as i64);
-        for page in 1..=10 {
+        for page in 1..=SERVARR_HISTORY_MAX_PAGES {
             let endpoint = format!(
-                "{}/api/v3/history?page={page}&pageSize=100&sortKey=date&sortDirection=descending&includeMovie=true",
+                "{}/api/v3/history?page={page}&pageSize={SERVARR_HISTORY_PAGE_SIZE}&sortKey=date&sortDirection=descending&includeMovie=true",
                 self.base_url
             );
             let response = self.get(&endpoint)?;
@@ -1956,6 +1959,137 @@ mod tests {
             .with_status(200)
             .with_body(json!({ "records": [] }).to_string())
             .create()
+    }
+
+    fn test_client(kind: IntegrationKind, url: String) -> ApiClient {
+        ApiClient::from_settings(
+            kind,
+            &ApiSettings {
+                url: Some(url),
+                api_key: Some("test-key".to_string()),
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn sonarr_recent_import_history_scans_beyond_ten_pages_within_lookback() {
+        let mut server = mockito::Server::new();
+        let mut mocks = Vec::new();
+        for page in 1..=10 {
+            mocks.push(
+                server
+                    .mock("GET", "/api/v3/history")
+                    .match_query(Matcher::UrlEncoded("page".into(), page.to_string()))
+                    .with_status(200)
+                    .with_body(
+                        json!({
+                            "records": [{
+                                "id": page,
+                                "eventType": "grabbed",
+                                "date": "9999-01-01T00:00:00Z"
+                            }]
+                        })
+                        .to_string(),
+                    )
+                    .create(),
+            );
+        }
+        mocks.push(
+            server
+                .mock("GET", "/api/v3/history")
+                .match_query(Matcher::UrlEncoded("page".into(), "11".into()))
+                .with_status(200)
+                .with_body(
+                    json!({
+                        "records": [{
+                            "id": 1234,
+                            "eventType": "downloadFolderImported",
+                            "episodeId": 77,
+                            "date": "9999-01-01T00:00:00Z"
+                        }]
+                    })
+                    .to_string(),
+                )
+                .create(),
+        );
+        mocks.push(
+            server
+                .mock("GET", "/api/v3/history")
+                .match_query(Matcher::UrlEncoded("page".into(), "12".into()))
+                .with_status(200)
+                .with_body(json!({ "records": [] }).to_string())
+                .create(),
+        );
+
+        let client = test_client(IntegrationKind::Sonarr, server.url());
+        let records = client.sonarr_recent_import_history(30).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].get("id").and_then(Value::as_i64), Some(1234));
+        for mock in mocks {
+            mock.assert();
+        }
+    }
+
+    #[test]
+    fn radarr_recent_import_history_scans_beyond_ten_pages_within_lookback() {
+        let mut server = mockito::Server::new();
+        let mut mocks = Vec::new();
+        for page in 1..=10 {
+            mocks.push(
+                server
+                    .mock("GET", "/api/v3/history")
+                    .match_query(Matcher::UrlEncoded("page".into(), page.to_string()))
+                    .with_status(200)
+                    .with_body(
+                        json!({
+                            "records": [{
+                                "id": page,
+                                "eventType": "grabbed",
+                                "date": "9999-01-01T00:00:00Z"
+                            }]
+                        })
+                        .to_string(),
+                    )
+                    .create(),
+            );
+        }
+        mocks.push(
+            server
+                .mock("GET", "/api/v3/history")
+                .match_query(Matcher::UrlEncoded("page".into(), "11".into()))
+                .with_status(200)
+                .with_body(
+                    json!({
+                        "records": [{
+                            "id": 4321,
+                            "eventType": "downloadFolderImported",
+                            "movieId": 88,
+                            "date": "9999-01-01T00:00:00Z"
+                        }]
+                    })
+                    .to_string(),
+                )
+                .create(),
+        );
+        mocks.push(
+            server
+                .mock("GET", "/api/v3/history")
+                .match_query(Matcher::UrlEncoded("page".into(), "12".into()))
+                .with_status(200)
+                .with_body(json!({ "records": [] }).to_string())
+                .create(),
+        );
+
+        let client = test_client(IntegrationKind::Radarr, server.url());
+        let records = client.radarr_recent_import_history(30).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].get("id").and_then(Value::as_i64), Some(4321));
+        for mock in mocks {
+            mock.assert();
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- fix Servarr history language audits so they scan until the configured lookback is exhausted instead of stopping after 10 pages
- apply the same pagination fix to Sonarr and Radarr recent import history scans
- add regression coverage for import records found on page 11

Fixes #134.

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- `FFMPEG_PKG_CONFIG_PATH=/workspace/target/vcpkg/installed/arm64-linux/lib/pkgconfig FFMPEG_INCLUDE_DIR=/workspace/target/vcpkg/installed/arm64-linux/include FFMPEG_LINK_MODE=static cargo test recent_import_history_scans_beyond_ten_pages_within_lookback`
