### PR TITLE
Fix post-merge resize benchmark CUDA fallback

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -498,6 +498,24 @@ jobs:
           command -v nvidia-smi >/dev/null 2>&1
           nvidia-smi -L
 
+      - name: Export benchmark CUDA runtime paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          cuda_runtime_paths=(
+            /opt/direct-play-nice/cudnn8-runtime/usr/lib
+            /opt/direct-play-nice/cudnn9-runtime/lib
+            /opt/direct-play-nice/nvrtc12-runtime/lib
+            /opt/direct-play-nice/cuda12-runtime/lib
+            /opt/direct-play-nice/ort116-runtime/lib
+            /opt/direct-play-nice/ort122-runtime/lib
+            /opt/cuda/lib64
+            /usr/lib
+          )
+          joined_paths="$(IFS=:; echo "${cuda_runtime_paths[*]}")"
+          echo "DPN_BENCH_CUDA_LD_LIBRARY_PATH=$joined_paths:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$joined_paths:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+
       - name: Run OCR benchmark (GPU attempt)
         id: ocr_gpu
         continue-on-error: true
@@ -602,6 +620,7 @@ jobs:
         run: |
           set -euo pipefail
           bin="${{ steps.cached-bin.outputs.bin_path }}"
+          export LD_LIBRARY_PATH="${DPN_BENCH_CUDA_LD_LIBRARY_PATH:-${LD_LIBRARY_PATH:-}}"
           export DIRECT_PLAY_NICE_LOCK_DIR=benchmark_artifacts/transcode/locks
           bash scripts/transcode-tools/run_transcode_benchmark.sh \
             --bin "$bin" \
@@ -624,9 +643,11 @@ jobs:
           DPN_RESIZE_HW_ACCEL: none
           DPN_RESIZE_CUDA: "1"
           DPN_RESIZE_CUDA_HW_ACCEL: nvenc
+          DPN_RESIZE_CUDA_REQUIRED: "0"
         run: |
           set -euo pipefail
           bin="${{ steps.cached-bin.outputs.bin_path }}"
+          export LD_LIBRARY_PATH="${DPN_BENCH_CUDA_LD_LIBRARY_PATH:-${LD_LIBRARY_PATH:-}}"
           export DPN_RESIZE_BENCH_BIN="$bin"
           export DIRECT_PLAY_NICE_LOCK_DIR=benchmark_artifacts/resize/locks
           bash scripts/resize-tools/run_resize_benchmark.sh
@@ -642,6 +663,9 @@ jobs:
           [[ -f benchmark_artifacts/transcode/hw.log ]] && cp -f benchmark_artifacts/transcode/hw.log benchmark_artifacts/TRANSCODE_HW.log || true
           [[ -f benchmark_artifacts/transcode/meta.txt ]] && cp -f benchmark_artifacts/transcode/meta.txt benchmark_artifacts/TRANSCODE_META.txt || true
           [[ -f benchmark_artifacts/resize/resize_report.csv ]] && cp -f benchmark_artifacts/resize/resize_report.csv benchmark_artifacts/RESIZE_BENCHMARK.csv || true
+          if compgen -G 'benchmark_artifacts/resize/*.log' > /dev/null; then
+            tar -czf benchmark_artifacts/RESIZE_BENCHMARK_LOGS.tar.gz -C benchmark_artifacts/resize ./*.log
+          fi
           [[ -f benchmark_artifacts/ocr/benchmark_summary.md ]] && cp -f benchmark_artifacts/ocr/benchmark_summary.md benchmark_artifacts/OCR_BENCHMARK.md || true
           [[ -f benchmark_artifacts/ocr/benchmark_summary.json ]] && cp -f benchmark_artifacts/ocr/benchmark_summary.json benchmark_artifacts/OCR_BENCHMARK.json || true
           [[ -f benchmark_artifacts/ocr/run.log ]] && cp -f benchmark_artifacts/ocr/run.log benchmark_artifacts/OCR_BENCHMARK.log || true
@@ -715,6 +739,7 @@ jobs:
             benchmark_artifacts/TRANSCODE_HW.log
             benchmark_artifacts/TRANSCODE_META.txt
             benchmark_artifacts/RESIZE_BENCHMARK.csv
+            benchmark_artifacts/RESIZE_BENCHMARK_LOGS.tar.gz
             benchmark_artifacts/OCR_BENCHMARK.md
             benchmark_artifacts/OCR_BENCHMARK.json
             benchmark_artifacts/OCR_BENCHMARK.log

--- a/scripts/resize-tools/run_resize_benchmark.sh
+++ b/scripts/resize-tools/run_resize_benchmark.sh
@@ -58,15 +58,21 @@ ffmpeg -hide_banner -y -i "$source_high" \
   -vf "scale=640:360:flags=lanczos,format=yuv420p" \
   -c:v libx264 -preset veryfast -crf 16 -an "$ref"
 
+candidate_log_path() {
+  local output="$1"
+  printf "%s/run_%s.log" "$work_dir" "$(basename "$output")"
+}
+
 run_candidate() {
   local quality="$1"
   local backend="$2"
   local hw_accel="$3"
   local output="$4"
-  local started ended elapsed fps realtime size_bytes
+  local log_file started ended elapsed fps realtime size_bytes
 
+  log_file="$(candidate_log_path "$output")"
   started="$(date +%s.%N)"
-  "$bin" \
+  if ! "$bin" \
     --config-file "$config_file" \
     --device chromecast \
     --hw-accel "$hw_accel" \
@@ -74,7 +80,11 @@ run_candidate() {
     --resize-quality "$quality" \
     --resize-backend "$backend" \
     --skip-codec-check \
-    "$source_high" "$output" >/dev/null
+    "$source_high" "$output" >"$log_file" 2>&1; then
+    echo "resize candidate failed: quality=$quality backend=$backend hw_accel=$hw_accel log=$log_file" >&2
+    tail -n 80 "$log_file" >&2 || true
+    return 1
+  fi
   ended="$(date +%s.%N)"
 
   elapsed="$(awk -v s="$started" -v e="$ended" 'BEGIN { printf "%.3f", e - s }')"
@@ -83,6 +93,34 @@ run_candidate() {
   size_bytes="$(wc -c < "$output" | tr -d ' ')"
 
   printf "%s,%s,%s,%s,%s,%s,%s" "$quality" "$backend" "$hw_accel" "$elapsed" "$fps" "$realtime" "$size_bytes"
+}
+
+append_candidate() {
+  local quality="$1"
+  local backend="$2"
+  local hw_accel="$3"
+  local output="$4"
+  local required="${5:-1}"
+  local row_prefix status
+
+  if row_prefix="$(run_candidate "$quality" "$backend" "$hw_accel" "$output")"; then
+    {
+      printf "%s" "$row_prefix"
+      metric_summary "$output"
+    } >> "$report"
+    return 0
+  fi
+
+  status=$?
+  printf "%s,%s,%s,na,na,na,na,na,na,na,na,na,na,na,na,na,na,na,na\n" \
+    "$quality" "$backend" "$hw_accel" >> "$report"
+
+  if [ "$required" = "1" ]; then
+    return "$status"
+  fi
+
+  echo "optional resize candidate failed; continuing because it is not required: quality=$quality backend=$backend hw_accel=$hw_accel" >&2
+  return 0
 }
 
 metric_field() {
@@ -177,25 +215,17 @@ metric_summary() {
 
 echo "quality,backend,hw_accel,elapsed_seconds,fps,realtime_factor,size_bytes,vmaf,psnr_y,psnr_u,psnr_v,psnr_avg,psnr_min,psnr_max,ssim_y,ssim_u,ssim_v,ssim_all,ssim_db" > "$report"
 
-{
-  run_candidate "fast-bilinear" "software" "none" "$baseline"
-  metric_summary "$baseline"
-} >> "$report"
+append_candidate "fast-bilinear" "software" "none" "$baseline"
 
 for quality in bilinear bicubic lanczos spline; do
   output="$work_dir/resize_${quality}.mp4"
-  {
-    run_candidate "$quality" "software" "none" "$output"
-    metric_summary "$output"
-  } >> "$report"
+  append_candidate "$quality" "software" "none" "$output"
 done
 
 if [ "${DPN_RESIZE_CUDA:-0}" = "1" ]; then
   output="$work_dir/resize_lanczos_cuda.mp4"
-  {
-    run_candidate "lanczos" "cuda" "${DPN_RESIZE_CUDA_HW_ACCEL:-nvenc}" "$output"
-    metric_summary "$output"
-  } >> "$report"
+  cuda_required="${DPN_RESIZE_CUDA_REQUIRED:-0}"
+  append_candidate "lanczos" "cuda" "${DPN_RESIZE_CUDA_HW_ACCEL:-nvenc}" "$output" "$cuda_required"
 fi
 
 echo "Resize benchmark report: $report"


### PR DESCRIPTION
## Summary
- add the benchmark CUDA/ORT runtime paths to post-merge transcode and resize benchmark steps
- make the optional CUDA resize candidate report `na` metrics and continue when CUDA resize is unavailable
- capture per-candidate resize logs and upload them as benchmark artifacts for diagnostics

## Validation
- `bash -n scripts/resize-tools/run_resize_benchmark.sh`
- parsed `.github/workflows/benchmarks-manual.yml` with PyYAML
- ran resize benchmark locally with a fake DPN that fails only the CUDA candidate; script exited 0 and emitted a CUDA `na` row
- ran the updated resize benchmark script on plexserver against `/usr/local/bin/direct_play_nice`; CUDA resize still reports unavailable, but the benchmark exits 0 and preserves logs

Fixes the failed post-merge benchmark run where the optional CUDA resize candidate failed the entire workflow.