### PR TITLE
Fix CUDA resize diagnostics and benchmark reporting

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -115,9 +115,9 @@ jobs:
             target/vcpkg/scripts
             target/vcpkg/triplets
             target/vcpkg/vcpkg
-          key: vcpkg-bench-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'vcpkg.json', 'vcpkg-configuration.json', 'VCPKG_DEPS_LIST.txt') }}
+          key: vcpkg-bench-scale-cuda-v1-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'vcpkg.json', 'vcpkg-configuration.json', 'VCPKG_DEPS_LIST.txt') }}
           restore-keys: |
-            vcpkg-bench-${{ runner.os }}-
+            vcpkg-bench-scale-cuda-v1-${{ runner.os }}-
 
       - name: Build vcpkg dependencies
         if: steps.cached-bin.outputs.missing == 'true'
@@ -344,9 +344,9 @@ jobs:
             target/vcpkg/scripts
             target/vcpkg/triplets
             target/vcpkg/vcpkg
-          key: vcpkg-bench-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'vcpkg.json', 'vcpkg-configuration.json', 'VCPKG_DEPS_LIST.txt') }}
+          key: vcpkg-bench-scale-cuda-v1-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'vcpkg.json', 'vcpkg-configuration.json', 'VCPKG_DEPS_LIST.txt') }}
           restore-keys: |
-            vcpkg-bench-${{ runner.os }}-
+            vcpkg-bench-scale-cuda-v1-${{ runner.os }}-
 
       - name: Build vcpkg dependencies
         if: steps.cached-bin.outputs.missing == 'true'
@@ -389,14 +389,36 @@ jobs:
           joined_paths="$(IFS=:; echo "${lib_paths[*]}")"
           echo "LD_LIBRARY_PATH=$joined_paths:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
 
-      - name: Validate VCPKG root
+      - name: Validate VCPKG FFmpeg CUDA resize support
         if: steps.cached-bin.outputs.missing == 'true'
         shell: bash
         run: |
           set -euo pipefail
           if [[ ! -f "$VCPKG_ROOT/.vcpkg-root" ]]; then
-            echo "::warning title=Missing vcpkg workspace::$VCPKG_ROOT/.vcpkg-root not found; continuing with local toolchain/runtime."
+            echo "::error title=Missing vcpkg workspace::$VCPKG_ROOT/.vcpkg-root not found."
+            exit 1
           fi
+
+          config_mak="$VCPKG_ROOT/buildtrees/ffmpeg/x64-linux-rel/ffbuild/config.mak"
+          avfilter_lib="$VCPKG_ROOT/installed/x64-linux/lib/libavfilter.a"
+          missing=()
+          if [[ ! -f "$config_mak" ]] || ! grep -q '^CONFIG_SCALE_CUDA_FILTER=yes$' "$config_mak"; then
+            missing+=("CONFIG_SCALE_CUDA_FILTER=yes in $config_mak")
+          fi
+          if [[ ! -f "$avfilter_lib" ]] || ! ar t "$avfilter_lib" | grep '^vf_scale_cuda\.o$' >/dev/null; then
+            missing+=("vf_scale_cuda.o in $avfilter_lib")
+          fi
+          if [[ ! -f "$avfilter_lib" ]] || ! strings "$avfilter_lib" | grep 'scale_cuda' >/dev/null; then
+            missing+=("scale_cuda symbols/strings in $avfilter_lib")
+          fi
+          if [[ "${#missing[@]}" -ne 0 ]]; then
+            echo "::error title=VCPKG FFmpeg missing CUDA resize support::Rebuild FFmpeg with --enable-cuda-llvm --enable-filter=scale_cuda. Missing: ${missing[*]}"
+            if [[ -f "$config_mak" ]]; then
+              grep -E 'CONFIG_SCALE_CUDA_FILTER|cuda_llvm|cuda_nvcc' "$config_mak" || true
+            fi
+            exit 1
+          fi
+          echo "Validated vcpkg FFmpeg scale_cuda support in $VCPKG_ROOT."
 
       - name: Export LIBCLANG_PATH
         if: steps.cached-bin.outputs.missing == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0-beta.3] - 2026-06-08
+
+### 🛠️ CUDA Resize Fixes
+
+- Fixed CUDA resize reliability on the Plex benchmark runner by requiring the
+  linked FFmpeg build to expose `scale_cuda` before selecting the CUDA resize
+  path.
+- Reported CUDA resize prerequisites individually so missing decode, encoder,
+  device, quality, or linked-filter support is visible in logs and probe output.
+- Improved resize benchmark failure reporting with explicit status, failure
+  reason, and log path fields, including `linked_ffmpeg_scale_cuda_unavailable`
+  for FFmpeg builds without `scale_cuda`.
+
+### 🧪 CUDA Resize Validation
+
+- Added manual benchmark workflow validation that fails clearly when vcpkg
+  FFmpeg is missing CUDA resize support.
+- Validated required CUDA resize on `plexserver` with `scale_cuda` selected and
+  the CUDA benchmark row completing with `status=ok`.
+
 ## [1.1.0-beta.2] - 2026-05-27
 
 ### 🛠️ Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 edition = "2021"
 
 

--- a/scripts/resize-tools/run_resize_benchmark.sh
+++ b/scripts/resize-tools/run_resize_benchmark.sh
@@ -63,6 +63,31 @@ candidate_log_path() {
   printf "%s/run_%s.log" "$work_dir" "$(basename "$output")"
 }
 
+csv_escape() {
+  local value="${1:-}"
+  value="${value//$'\n'/ }"
+  value="${value//$'\r'/ }"
+  value="${value//\"/\"\"}"
+  printf '"%s"' "$value"
+}
+
+classify_failure_reason() {
+  local log_file="$1"
+  if grep -Eiq "linked FFmpeg filter 'scale_cuda' is missing|FFmpeg filter 'scale_cuda' is not available|scale_cuda.*(missing|unavailable|not available)" "$log_file" 2>/dev/null; then
+    printf "linked_ffmpeg_scale_cuda_unavailable"
+  elif grep -Eiq -- "--resize-backend=cuda unavailable" "$log_file" 2>/dev/null; then
+    printf "cuda_resize_prerequisite_failed"
+  elif grep -Eiq "CUDA hardware decode is inactive|requires CUDA decode" "$log_file" 2>/dev/null; then
+    printf "cuda_hw_decode_unavailable"
+  elif grep -Eiq "selected encoder is not NVENC|NVENC|nvenc" "$log_file" 2>/dev/null; then
+    printf "nvenc_unavailable"
+  elif grep -Eiq "CUDA hardware device is unavailable|No CUDA device|cuda.*device" "$log_file" 2>/dev/null; then
+    printf "cuda_device_unavailable"
+  else
+    printf "candidate_failed"
+  fi
+}
+
 run_candidate() {
   local quality="$1"
   local backend="$2"
@@ -101,28 +126,34 @@ append_candidate() {
   local hw_accel="$3"
   local output="$4"
   local required="${5:-1}"
-  local row_prefix status
+  local row_prefix status log_file failure_reason
 
+  log_file="$(candidate_log_path "$output")"
   if row_prefix="$(run_candidate "$quality" "$backend" "$hw_accel" "$output")"; then
     {
       printf "%s" "$row_prefix"
       metric_summary "$output"
+      printf ",ok,,"
+      csv_escape "$log_file"
+      printf "\n"
     } >> "$report"
     return 0
   fi
 
   status=$?
-  printf "%s,%s,%s,na,na,na,na,na,na,na,na,na,na,na,na,na,na,na,na\n" \
-    "$quality" "$backend" "$hw_accel" >> "$report"
+  failure_reason="$(classify_failure_reason "$log_file")"
+  printf "%s,%s,%s,na,na,na,na,na,na,na,na,na,na,na,na,na,na,na,na,failed,%s," \
+    "$quality" "$backend" "$hw_accel" "$failure_reason" >> "$report"
+  csv_escape "$log_file" >> "$report"
+  printf "\n" >> "$report"
 
   if [ "$required" = "1" ]; then
     return "$status"
   fi
 
-  echo "optional resize candidate failed; continuing because it is not required: quality=$quality backend=$backend hw_accel=$hw_accel" >&2
+  echo "optional resize candidate failed; continuing because it is not required: quality=$quality backend=$backend hw_accel=$hw_accel reason=$failure_reason" >&2
   return 0
 }
-
 metric_field() {
   local line="$1"
   local name="$2"
@@ -207,13 +238,13 @@ metric_summary() {
   ssim_all="$(metric_field "$ssim_line" "All")"
   ssim_db="$(ssim_db_value "$ssim_line")"
 
-  printf ",%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n" \
+  printf ",%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" \
     "${vmaf:-na}" \
     "${psnr_y:-na}" "${psnr_u:-na}" "${psnr_v:-na}" "${psnr_avg:-na}" "${psnr_min:-na}" "${psnr_max:-na}" \
     "${ssim_y:-na}" "${ssim_u:-na}" "${ssim_v:-na}" "${ssim_all:-na}" "${ssim_db:-na}"
 }
 
-echo "quality,backend,hw_accel,elapsed_seconds,fps,realtime_factor,size_bytes,vmaf,psnr_y,psnr_u,psnr_v,psnr_avg,psnr_min,psnr_max,ssim_y,ssim_u,ssim_v,ssim_all,ssim_db" > "$report"
+echo "quality,backend,hw_accel,elapsed_seconds,fps,realtime_factor,size_bytes,vmaf,psnr_y,psnr_u,psnr_v,psnr_avg,psnr_min,psnr_max,ssim_y,ssim_u,ssim_v,ssim_all,ssim_db,status,failure_reason,log_path" > "$report"
 
 append_candidate "fast-bilinear" "software" "none" "$baseline"
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -27,6 +27,22 @@ pub enum HwAccel {
     Amf,
 }
 
+/// Reports whether the linked FFmpeg avfilter build exposes the `scale_cuda` filter.
+pub fn scale_cuda_filter_available() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        let Ok(name) = CString::new("scale_cuda") else {
+            return false;
+        };
+        unsafe { !ffi::avfilter_get_by_name(name.as_ptr()).is_null() }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
 /// Attempts to create an FFmpeg hardware device by name.
 ///
 /// Returns a retained `AVBufferRef` on success.
@@ -326,6 +342,14 @@ pub fn print_probe_codecs(only_video: bool, only_hw: bool) {
         println!("  avformat: {}", ver_fmt);
         println!("  avutil: {}", ver_util);
         println!("Configuration:\n  {}\n", conf.to_string_lossy());
+        println!(
+            "CUDA resize filters:\n  - scale_cuda {:<11} (linked FFmpeg avfilter)\n",
+            if scale_cuda_filter_available() {
+                "available"
+            } else {
+                "unavailable"
+            }
+        );
 
         let mut opaque: *mut c_void = std::ptr::null_mut();
         let mut enc_count = 0usize;
@@ -450,10 +474,19 @@ pub struct CodecEntry {
 }
 
 #[derive(Serialize)]
+/// Structured summary of CUDA resize probe information.
+pub struct CudaResizeProbe {
+    /// Whether the linked FFmpeg avfilter build exposes the `scale_cuda` filter.
+    pub scale_cuda_filter_available: bool,
+}
+
+#[derive(Serialize)]
 /// Structured summary of hardware and codec probe information.
 pub struct CodecProbeSummary {
     /// FFmpeg version and configuration metadata.
     pub ffmpeg: serde_json::Value,
+    /// CUDA resize-specific FFmpeg filter availability.
+    pub cuda_resize: CudaResizeProbe,
     /// Hardware-device probe rows.
     pub devices: Vec<HwDeviceEntry>,
     /// Hardware-encoder probe rows.
@@ -600,6 +633,9 @@ pub fn gather_probe_json(
         }
         CodecProbeSummary {
             ffmpeg: ver,
+            cuda_resize: CudaResizeProbe {
+                scale_cuda_filter_available: scale_cuda_filter_available(),
+            },
             devices: device_entries,
             hw_encoders: hw_encs,
             encoders,

--- a/src/transcoder/app_convert.rs
+++ b/src/transcoder/app_convert.rs
@@ -451,14 +451,31 @@ pub(crate) fn convert_video_file(
 
                 let dimensions_change = input_stream_codecpar.width != encode_context.width
                     || input_stream_codecpar.height != encode_context.height;
-                let can_use_cuda_resize = hw_decoder_active
-                    && using_hw_encoder
-                    && encoder_name_lower.contains("nvenc")
-                    && maybe_hw_dev.is_some()
-                    && cuda_resize_supported_for_quality(resize_quality)
-                    && scale_cuda_filter_available();
+                let cuda_resize_prereqs = CudaResizePrerequisites::new(
+                    dimensions_change,
+                    hw_decoder_active,
+                    using_hw_encoder,
+                    encoder_name_lower.contains("nvenc"),
+                    maybe_hw_dev.is_some(),
+                    cuda_resize_supported_for_quality(resize_quality),
+                    scale_cuda_filter_available(),
+                );
+                if dimensions_change
+                    || matches!(resize_backend, ResizeBackend::Cuda | ResizeBackend::Auto)
+                {
+                    info!(
+                        "CUDA resize prerequisites: dimensions_change={}, cuda_hw_decode={}, hardware_encoder={}, nvenc_encoder={}, cuda_hw_device={}, quality_supported={}, linked_scale_cuda_filter={}",
+                        cuda_resize_prereqs.dimensions_change,
+                        cuda_resize_prereqs.cuda_hw_decode,
+                        cuda_resize_prereqs.hardware_encoder,
+                        cuda_resize_prereqs.nvenc_encoder,
+                        cuda_resize_prereqs.cuda_hw_device,
+                        cuda_resize_prereqs.quality_supported,
+                        cuda_resize_prereqs.linked_scale_cuda_filter,
+                    );
+                }
                 active_resize_backend =
-                    select_resize_backend(resize_backend, dimensions_change, can_use_cuda_resize)?;
+                    select_resize_backend(resize_backend, &cuda_resize_prereqs)?;
                 if matches!(active_resize_backend, ResizeBackend::Cuda) {
                     info!(
                         "Resize backend selected: cuda (scale_cuda, quality {}, {}x{} -> {}x{})",
@@ -708,22 +725,101 @@ pub(crate) fn convert_video_file(
     Ok(ConversionOutcome { h264_verification })
 }
 
+#[derive(Clone, Copy, Debug)]
+struct CudaResizePrerequisites {
+    dimensions_change: bool,
+    cuda_hw_decode: bool,
+    hardware_encoder: bool,
+    nvenc_encoder: bool,
+    cuda_hw_device: bool,
+    quality_supported: bool,
+    linked_scale_cuda_filter: bool,
+}
+
+impl CudaResizePrerequisites {
+    fn new(
+        dimensions_change: bool,
+        cuda_hw_decode: bool,
+        hardware_encoder: bool,
+        nvenc_encoder: bool,
+        cuda_hw_device: bool,
+        quality_supported: bool,
+        linked_scale_cuda_filter: bool,
+    ) -> Self {
+        Self {
+            dimensions_change,
+            cuda_hw_decode,
+            hardware_encoder,
+            nvenc_encoder,
+            cuda_hw_device,
+            quality_supported,
+            linked_scale_cuda_filter,
+        }
+    }
+
+    fn available(self) -> bool {
+        self.dimensions_change
+            && self.cuda_hw_decode
+            && self.hardware_encoder
+            && self.nvenc_encoder
+            && self.cuda_hw_device
+            && self.quality_supported
+            && self.linked_scale_cuda_filter
+    }
+
+    fn missing_reasons(self) -> Vec<&'static str> {
+        let mut reasons = Vec::new();
+        if !self.dimensions_change {
+            reasons.push("video dimensions are unchanged");
+        }
+        if !self.cuda_hw_decode {
+            reasons.push("CUDA hardware decode is inactive");
+        }
+        if !self.hardware_encoder {
+            reasons.push("hardware encoder is inactive");
+        }
+        if !self.nvenc_encoder {
+            reasons.push("selected encoder is not NVENC");
+        }
+        if !self.cuda_hw_device {
+            reasons.push("CUDA hardware device is unavailable");
+        }
+        if !self.quality_supported {
+            reasons.push("resize quality is not scale_cuda-compatible (supported: bilinear, bicubic, lanczos)");
+        }
+        if !self.linked_scale_cuda_filter {
+            reasons.push("linked FFmpeg filter 'scale_cuda' is missing");
+        }
+        reasons
+    }
+
+    fn missing_reason_summary(self) -> String {
+        self.missing_reasons().join("; ")
+    }
+}
+
 fn select_resize_backend(
     requested: ResizeBackend,
-    dimensions_change: bool,
-    cuda_available: bool,
+    prerequisites: &CudaResizePrerequisites,
 ) -> Result<ResizeBackend> {
-    if !dimensions_change {
+    if !prerequisites.dimensions_change {
         return Ok(ResizeBackend::Software);
     }
 
     match requested {
         ResizeBackend::Software => Ok(ResizeBackend::Software),
-        ResizeBackend::Auto if cuda_available => Ok(ResizeBackend::Cuda),
-        ResizeBackend::Auto => Ok(ResizeBackend::Software),
-        ResizeBackend::Cuda if cuda_available => Ok(ResizeBackend::Cuda),
+        ResizeBackend::Auto if prerequisites.available() => Ok(ResizeBackend::Cuda),
+        ResizeBackend::Auto => {
+            info!(
+                "CUDA resize unavailable; falling back to software resize: {}",
+                prerequisites.missing_reason_summary()
+            );
+            Ok(ResizeBackend::Software)
+        }
+        ResizeBackend::Cuda if prerequisites.available() => Ok(ResizeBackend::Cuda),
         ResizeBackend::Cuda => bail!(
-            "--resize-backend=cuda requires CUDA decode, NVENC encode, scale_cuda filter support, and a scale_cuda-compatible resize quality (bilinear, bicubic, lanczos)"
+            "--resize-backend=cuda unavailable: {}",
+            prerequisites.missing_reason_summary()
         ),
     }
 }
@@ -972,32 +1068,41 @@ fn verify_h264_output(request: H264VerificationRequest<'_>) -> Result<Option<H26
 mod tests {
     use super::*;
 
+    fn available_cuda_resize_prerequisites() -> CudaResizePrerequisites {
+        CudaResizePrerequisites::new(true, true, true, true, true, true, true)
+    }
+
     #[test]
     fn cuda_resize_backend_is_ignored_when_dimensions_do_not_change() {
+        let prerequisites =
+            CudaResizePrerequisites::new(false, false, false, false, false, false, false);
         assert_eq!(
-            select_resize_backend(ResizeBackend::Cuda, false, false).unwrap(),
+            select_resize_backend(ResizeBackend::Cuda, &prerequisites).unwrap(),
             ResizeBackend::Software
         );
     }
 
     #[test]
     fn auto_resize_backend_prefers_cuda_only_when_available() {
+        let available = available_cuda_resize_prerequisites();
         assert_eq!(
-            select_resize_backend(ResizeBackend::Auto, true, true).unwrap(),
+            select_resize_backend(ResizeBackend::Auto, &available).unwrap(),
             ResizeBackend::Cuda
         );
+        let unavailable = CudaResizePrerequisites::new(true, true, true, true, true, true, false);
         assert_eq!(
-            select_resize_backend(ResizeBackend::Auto, true, false).unwrap(),
+            select_resize_backend(ResizeBackend::Auto, &unavailable).unwrap(),
             ResizeBackend::Software
         );
     }
 
     #[test]
-    fn required_cuda_resize_backend_fails_when_unavailable() {
-        let err = select_resize_backend(ResizeBackend::Cuda, true, false).unwrap_err();
+    fn required_cuda_resize_backend_fails_with_missing_reason() {
+        let prerequisites = CudaResizePrerequisites::new(true, true, true, true, true, true, false);
+        let err = select_resize_backend(ResizeBackend::Cuda, &prerequisites).unwrap_err();
         assert!(
             err.to_string()
-                .contains("--resize-backend=cuda requires CUDA decode"),
+                .contains("linked FFmpeg filter 'scale_cuda' is missing"),
             "unexpected error: {err}"
         );
     }

--- a/src/transcoder/cuda_resize.rs
+++ b/src/transcoder/cuda_resize.rs
@@ -18,10 +18,6 @@ mod non_linux {
         false
     }
 
-    pub(crate) fn scale_cuda_filter_available() -> bool {
-        false
-    }
-
     pub(crate) fn attach_cuda_encoder_frames_context(
         _encode_context: &mut AVCodecContext,
         _device: *mut ffi::AVBufferRef,

--- a/src/transcoder/cuda_resize/linux.rs
+++ b/src/transcoder/cuda_resize/linux.rs
@@ -8,6 +8,7 @@ use rsmpeg::ffi;
 use std::ffi::CString;
 use std::ptr;
 
+use crate::gpu::scale_cuda_filter_available;
 use crate::transcoder::ffmpeg_diagnostics::av_error_to_string;
 use crate::types::ResizeQuality;
 
@@ -61,13 +62,6 @@ pub(crate) fn attach_cuda_encoder_frames_context(
         (*encode_context.as_mut_ptr()).hw_frames_ctx = frames_ref;
     }
     Ok(())
-}
-
-pub(crate) fn scale_cuda_filter_available() -> bool {
-    let Ok(name) = CString::new("scale_cuda") else {
-        return false;
-    };
-    unsafe { !ffi::avfilter_get_by_name(name.as_ptr()).is_null() }
 }
 
 pub(crate) struct CudaResizeFilter {


### PR DESCRIPTION
## Summary
- report CUDA resize prerequisites individually, including linked FFmpeg `scale_cuda` availability
- expose linked `scale_cuda` availability in probe text and JSON output
- improve resize benchmark CSV/reporting with `status`, `failure_reason`, and `log_path`, including `linked_ffmpeg_scale_cuda_unavailable`
- validate vcpkg FFmpeg CUDA resize support in the manual benchmark workflow and bump the vcpkg cache key
- prepare release `1.1.0-beta.3` with matching changelog notes

## Plexserver verification
- rebuilt FFmpeg under test plexserver home with `--enable-cuda-llvm --enable-filter=scale_cuda`
- verified `CONFIG_SCALE_CUDA_FILTER=yes`, `vf_scale_cuda.o`, `vf_scale_cuda.ptx.o`, and `cuda_llvm=yes`
- verified probe text reports `scale_cuda available` and probe JSON reports `cuda_resize.scale_cuda_filter_available=true`
- ran required CUDA resize benchmark on `plexserver`; CUDA row completed with `status=ok`
- log confirmed `linked_scale_cuda_filter=true` and `Resize backend selected: cuda`

## Tests
- `cargo fmt --check`
- `bash -n scripts/resize-tools/run_resize_benchmark.sh`
- workflow YAML parse check
- `git diff --check`
- `bash scripts/validate_release_changelog.sh`
- `cargo test --release --no-run` on `plexserver`
- relevant resize/backend tests on `plexserver`
- manual benchmark workflow validation snippet on `plexserver`

## Note
The workflow now fails clearly if the active vcpkg FFmpeg build does not include `scale_cuda`; the FFmpeg build under test plexserver home has been rebuilt with the required support.