### PR TITLE
Retry bitmap OCR after subtitle remux

### DIFF
--- a/src/subtitle_ocr/mod.rs
+++ b/src/subtitle_ocr/mod.rs
@@ -55,8 +55,9 @@ use language::*;
 pub(crate) use muxing::{mux_text_tracks_from, remux_copy_streams};
 #[cfg(test)]
 use ocr_pipeline::{
-    apply_bitmap_subtitle_canvas_fallback, quality_fallback_thresholds, subtitle_rect_counts,
-    OcrQualityBaseline,
+    apply_bitmap_subtitle_canvas_fallback, normalize_bitmap_subtitle_stream_for_ocr,
+    quality_fallback_thresholds, should_retry_bitmap_ocr_with_external_remux, subtitle_rect_counts,
+    OcrDecodeOutcome, OcrQualityBaseline, OcrStreamRequest,
 };
 use text_render::*;
 

--- a/src/subtitle_ocr/ocr_pipeline.rs
+++ b/src/subtitle_ocr/ocr_pipeline.rs
@@ -117,10 +117,86 @@ struct CueBuildParams<'a> {
     ocr_engine: OcrEngine,
 }
 
+#[derive(Debug)]
+pub(super) struct OcrDecodeOutcome {
+    pub(super) cues: Vec<SubtitleCue>,
+    pub(super) stream_codec_id: ffi::AVCodecID,
+    pub(super) subtitle_packet_count: usize,
+    pub(super) decoded_subtitle_count: usize,
+    pub(super) decoded_rect_count: usize,
+    pub(super) decoded_image_rect_count: usize,
+}
+
 pub(super) fn ocr_single_stream(
     request: &OcrStreamRequest<'_>,
     engine: &mut dyn SubtitleConverter,
 ) -> Result<Vec<SubtitleCue>> {
+    let mut outcome = ocr_single_stream_once(request, engine)?;
+
+    if should_retry_bitmap_ocr_with_external_remux(&outcome) {
+        match normalize_bitmap_subtitle_stream_for_ocr(request) {
+            Ok(Some(normalized_path)) => {
+                let normalized_input = normalized_path.to_string_lossy().into_owned();
+                let retry_request = OcrStreamRequest {
+                    input_path: &normalized_input,
+                    stream_index: 0,
+                    language: request.language,
+                    work_dir: request.work_dir,
+                    ocr_format: request.ocr_format,
+                    video_dimensions: request.video_dimensions,
+                    ocr_engine: request.ocr_engine,
+                };
+                let retry = ocr_single_stream_once(&retry_request, engine)?;
+                if !retry.cues.is_empty() {
+                    info!(
+                        "OCR subtitle stream {} recovered after ffmpeg subtitle remux fallback ({} cues)",
+                        request.stream_index,
+                        retry.cues.len()
+                    );
+                    return Ok(retry.cues);
+                }
+                warn!(
+                    "OCR subtitle stream {} ffmpeg subtitle remux fallback produced no cues; decoded_subtitles={}, decoded_rects={}, decoded_image_rects={}",
+                    request.stream_index,
+                    retry.decoded_subtitle_count,
+                    retry.decoded_rect_count,
+                    retry.decoded_image_rect_count
+                );
+                outcome = retry;
+            }
+            Ok(None) => {}
+            Err(err) => {
+                warn!(
+                    "OCR subtitle stream {} ffmpeg subtitle remux fallback failed: {err:#}",
+                    request.stream_index
+                );
+            }
+        }
+    }
+
+    if outcome.cues.is_empty()
+        && outcome.subtitle_packet_count > 0
+        && is_image_based_subtitle(outcome.stream_codec_id)
+    {
+        bail!(
+            "OCR produced no cues for bitmap subtitle stream {} ({}) despite reading {} subtitle packet(s); decoded_subtitles={}, decoded_rects={}, decoded_image_rects={}, video_dimensions={:?}. This usually means the bitmap subtitle decoder could not derive a valid canvas/rectangle layout.",
+            request.stream_index,
+            codec_name(outcome.stream_codec_id),
+            outcome.subtitle_packet_count,
+            outcome.decoded_subtitle_count,
+            outcome.decoded_rect_count,
+            outcome.decoded_image_rect_count,
+            request.video_dimensions
+        );
+    }
+
+    Ok(outcome.cues)
+}
+
+fn ocr_single_stream_once(
+    request: &OcrStreamRequest<'_>,
+    engine: &mut dyn SubtitleConverter,
+) -> Result<OcrDecodeOutcome> {
     let input_cstr = CString::new(request.input_path).context("input path has interior NUL")?;
     let mut ictx = AVFormatContextInput::open(input_cstr.as_c_str())?;
 
@@ -254,20 +330,91 @@ pub(super) fn ocr_single_stream(
 
     sanitize_cues(&mut cues, request.ocr_format);
 
-    if cues.is_empty() && subtitle_packet_count > 0 && is_image_based_subtitle(stream_codec_id) {
+    Ok(OcrDecodeOutcome {
+        cues,
+        stream_codec_id,
+        subtitle_packet_count,
+        decoded_subtitle_count,
+        decoded_rect_count,
+        decoded_image_rect_count,
+    })
+}
+
+pub(super) fn should_retry_bitmap_ocr_with_external_remux(outcome: &OcrDecodeOutcome) -> bool {
+    outcome.cues.is_empty()
+        && outcome.subtitle_packet_count > 0
+        && outcome.decoded_subtitle_count == 0
+        && is_image_based_subtitle(outcome.stream_codec_id)
+}
+
+pub(super) fn normalize_bitmap_subtitle_stream_for_ocr(
+    request: &OcrStreamRequest<'_>,
+) -> Result<Option<PathBuf>> {
+    let ffmpeg = env::var("DPN_FFMPEG_BINARY").unwrap_or_else(|_| "ffmpeg".to_string());
+    let output_path = request
+        .work_dir
+        .join(format!("ocr-s{}-normalized.mks", request.stream_index));
+    let map_arg = format!("0:{}", request.stream_index);
+
+    info!(
+        "Retrying OCR subtitle stream {} via ffmpeg subtitle remux fallback",
+        request.stream_index
+    );
+    let output = Command::new(&ffmpeg)
+        .arg("-hide_banner")
+        .arg("-loglevel")
+        .arg("error")
+        .arg("-y")
+        .arg("-i")
+        .arg(request.input_path)
+        .arg("-map")
+        .arg(&map_arg)
+        .arg("-c")
+        .arg("copy")
+        .arg("-f")
+        .arg("matroska")
+        .arg(&output_path)
+        .output()
+        .with_context(|| {
+            format!(
+                "running ffmpeg subtitle remux fallback for stream {}",
+                request.stream_index
+            )
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if stderr.is_empty() {
+            bail!(
+                "ffmpeg subtitle remux fallback failed for stream {} with status {}",
+                request.stream_index,
+                output.status
+            );
+        }
         bail!(
-            "OCR produced no cues for bitmap subtitle stream {} ({}) despite reading {} subtitle packet(s); decoded_subtitles={}, decoded_rects={}, decoded_image_rects={}, video_dimensions={:?}. This usually means the bitmap subtitle decoder could not derive a valid canvas/rectangle layout.",
+            "ffmpeg subtitle remux fallback failed for stream {} with status {}: {}",
             request.stream_index,
-            codec_name(stream_codec_id),
-            subtitle_packet_count,
-            decoded_subtitle_count,
-            decoded_rect_count,
-            decoded_image_rect_count,
-            request.video_dimensions
+            output.status,
+            stderr
         );
     }
 
-    Ok(cues)
+    let metadata = fs::metadata(&output_path).with_context(|| {
+        format!(
+            "ffmpeg subtitle remux fallback did not create {}",
+            output_path.display()
+        )
+    })?;
+    if metadata.len() == 0 {
+        warn!(
+            "ffmpeg subtitle remux fallback produced an empty file for stream {}",
+            request.stream_index
+        );
+        return Ok(None);
+    }
+
+    Ok(Some(output_path))
 }
 
 pub(super) fn apply_bitmap_subtitle_canvas_fallback(

--- a/src/subtitle_ocr/tests.rs
+++ b/src/subtitle_ocr/tests.rs
@@ -140,6 +140,85 @@ fn subtitle_rect_counts_handles_null_subtitle() {
 }
 
 #[test]
+fn bitmap_ocr_remux_retry_requires_packets_and_zero_decodes() {
+    let retry = OcrDecodeOutcome {
+        cues: Vec::new(),
+        stream_codec_id: ffi::AV_CODEC_ID_HDMV_PGS_SUBTITLE,
+        subtitle_packet_count: 12,
+        decoded_subtitle_count: 0,
+        decoded_rect_count: 0,
+        decoded_image_rect_count: 0,
+    };
+    assert!(should_retry_bitmap_ocr_with_external_remux(&retry));
+
+    let decoded_without_cues = OcrDecodeOutcome {
+        decoded_subtitle_count: 1,
+        ..retry
+    };
+    assert!(!should_retry_bitmap_ocr_with_external_remux(
+        &decoded_without_cues
+    ));
+
+    let text_subtitle = OcrDecodeOutcome {
+        decoded_subtitle_count: 0,
+        stream_codec_id: ffi::AV_CODEC_ID_SUBRIP,
+        ..decoded_without_cues
+    };
+    assert!(!should_retry_bitmap_ocr_with_external_remux(&text_subtitle));
+}
+
+#[cfg(unix)]
+#[test]
+fn bitmap_subtitle_normalization_invokes_ffmpeg_copy_remux() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = env_lock();
+    let temp = TempDir::new().expect("temp dir");
+    let fake_ffmpeg = temp.path().join("ffmpeg-stub");
+    let args_file = temp.path().join("args.txt");
+    std::fs::write(
+        &fake_ffmpeg,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$DPN_FFMPEG_ARGS\"\nout=\"\"\nfor arg do out=\"$arg\"; done\nprintf stub > \"$out\"\n",
+    )
+    .expect("write ffmpeg stub");
+    let mut perms = std::fs::metadata(&fake_ffmpeg)
+        .expect("stub metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_ffmpeg, perms).expect("chmod ffmpeg stub");
+
+    std::env::set_var("DPN_FFMPEG_BINARY", &fake_ffmpeg);
+    std::env::set_var("DPN_FFMPEG_ARGS", &args_file);
+
+    let request = OcrStreamRequest {
+        input_path: "/media/input.mkv",
+        stream_index: 3,
+        language: "eng",
+        work_dir: temp.path(),
+        ocr_format: OcrFormat::Srt,
+        video_dimensions: Some((1440, 1080)),
+        ocr_engine: OcrEngine::External,
+    };
+
+    let normalized = normalize_bitmap_subtitle_stream_for_ocr(&request)
+        .expect("normalization succeeds")
+        .expect("normalization output");
+
+    assert_eq!(normalized, temp.path().join("ocr-s3-normalized.mks"));
+    assert_eq!(
+        std::fs::read(&normalized).expect("normalized data"),
+        b"stub"
+    );
+    let args = std::fs::read_to_string(args_file).expect("captured args");
+    assert!(args.contains("-map\n0:3\n"), "args were {args:?}");
+    assert!(args.contains("-c\ncopy\n"), "args were {args:?}");
+    assert!(args.contains("-f\nmatroska\n"), "args were {args:?}");
+
+    std::env::remove_var("DPN_FFMPEG_BINARY");
+    std::env::remove_var("DPN_FFMPEG_ARGS");
+}
+
+#[test]
 fn external_ocr_command_parser_requires_program_name() {
     assert!(parse_external_ocr_argv("").is_err());
     assert!(parse_external_ocr_argv("   ").is_err());


### PR DESCRIPTION
## Summary

- Adds a targeted bitmap subtitle OCR retry for cases where the app reads image-subtitle packets but decodes zero subtitle objects.
- Normalizes only the failing subtitle stream through a temporary subtitle-only Matroska stream-copy remux, then retries OCR on the normalized stream.
- Keeps the existing OCR path unchanged unless the zero-decode bitmap failure mode is detected.
- Supports `DPN_FFMPEG_BINARY` for deployments that need a specific ffmpeg executable.

## Why

An anonymized full-length Matroska sample with a PGS subtitle stream reproduced a failure where the app read hundreds of subtitle packets, but the rsmpeg side-pass returned zero decoded subtitles, rectangles, and image rectangles. OCR recognition was never reached.

Validation ruled out the OCR engine and provider path: the same zero-decode failure reproduced with an external OCR stub. Direct FFmpeg C API probes decoded the original PGS payload successfully, and a lossless FFmpeg stream-copy remux made the existing deployed app OCR the same content successfully. This points to a container/layout quirk that can be normalized before retrying the subtitle-only OCR side pass.

## Validation

```bash
cargo fmt --check
git diff --check
VCPKG_ROOT=$PWD/target/vcpkg \
VCPKGRS_TRIPLET=arm64-linux \
PKG_CONFIG_PATH=$PWD/target/vcpkg/installed/arm64-linux/lib/pkgconfig \
cargo check --bins
VCPKG_ROOT=$PWD/target/vcpkg \
VCPKGRS_TRIPLET=arm64-linux \
PKG_CONFIG_PATH=$PWD/target/vcpkg/installed/arm64-linux/lib/pkgconfig \
cargo check --tests
```

Known local limitation:

```bash
VCPKG_ROOT=$PWD/target/vcpkg \
VCPKGRS_TRIPLET=arm64-linux \
PKG_CONFIG_PATH=$PWD/target/vcpkg/installed/arm64-linux/lib/pkgconfig \
cargo test bitmap_ocr_remux_retry_requires_packets_and_zero_decodes
```

This reaches the test-binary link step and fails on unrelated local static vcpkg symbols from `libpng`/`fontconfig` (`deflate*`, `FT_Get_*`). `cargo check --tests` passes and verifies the new test code compiles.

## Private end-to-end validation

Built this PR on the private deployment host using its existing vcpkg FFmpeg environment plus the host's already-generated FFmpeg binding artifact. The test binary was not installed and did not replace the deployed binary.

Using a hardlink copy of the private full-length Matroska sample, the deployed `1.1.0-beta.2` binary still reproduced the original failure with the same external OCR stub:

```text
OCR produced no cues for bitmap subtitle stream 3 (hdmv_pgs_subtitle) despite reading 340 subtitle packet(s); decoded_subtitles=0, decoded_rects=0, decoded_image_rects=0
```

The PR `1.1.0-beta.3` test binary, run against the same hardlink sample with the same external OCR stub and `--delete-source false`, exited successfully and produced 171 OCR cues:

```text
OCR subtitle stream 3 -> '<workdir>/stream-3.srt' (171 cues, format=Srt)
```


