### PR TITLE
Fix Servarr filename quality for device-capped downscales

### DIFF
--- a/src/servarr/path_policy.rs
+++ b/src/servarr/path_policy.rs
@@ -64,7 +64,10 @@ pub(super) fn resolve_output_path(
 fn update_filename_quality(stem: &str, desired_video_quality: VideoQuality) -> String {
     let target = match desired_video_quality {
         VideoQuality::MatchSource => return stem.to_string(),
-        quality => quality.to_string(),
+        quality => quality,
+    };
+    let Some(target_height) = quality_height(target) else {
+        return stem.to_string();
     };
 
     let mut replaced = String::with_capacity(stem.len());
@@ -85,8 +88,7 @@ fn update_filename_quality(stem: &str, desired_video_quality: VideoQuality) -> S
 
         if let Some(start) = digit_start {
             let digits = &stem[start..p_idx];
-            let is_known_quality =
-                matches!(digits, "360" | "480" | "720" | "1080" | "1440" | "2160");
+            let existing_height = known_quality_height(digits);
             let before_ok = stem[..start]
                 .chars()
                 .next_back()
@@ -96,21 +98,50 @@ fn update_filename_quality(stem: &str, desired_video_quality: VideoQuality) -> S
                 .next()
                 .is_none_or(|ch| !ch.is_ascii_alphanumeric());
 
-            if is_known_quality && before_ok && after_ok {
-                last_match = Some((start, p_idx + 1));
+            if let Some(existing_height) = existing_height {
+                if before_ok && after_ok {
+                    last_match = Some((start, p_idx + 1, existing_height));
+                }
             }
         }
 
         search_start = p_idx + 'p'.len_utf8();
     }
 
-    if let Some((start, end)) = last_match {
+    if let Some((start, end, existing_height)) = last_match {
+        if target_height > existing_height {
+            return stem.to_string();
+        }
         replaced.push_str(&stem[..start]);
-        replaced.push_str(&target);
+        replaced.push_str(&target.to_string());
         replaced.push_str(&stem[end..]);
         replaced
     } else {
         stem.to_string()
+    }
+}
+
+fn quality_height(quality: VideoQuality) -> Option<u16> {
+    match quality {
+        VideoQuality::MatchSource => None,
+        VideoQuality::P360 => Some(360),
+        VideoQuality::P480 => Some(480),
+        VideoQuality::P720 => Some(720),
+        VideoQuality::P1080 => Some(1080),
+        VideoQuality::P1440 => Some(1440),
+        VideoQuality::P2160 => Some(2160),
+    }
+}
+
+fn known_quality_height(digits: &str) -> Option<u16> {
+    match digits {
+        "360" => Some(360),
+        "480" => Some(480),
+        "720" => Some(720),
+        "1080" => Some(1080),
+        "1440" => Some(1440),
+        "2160" => Some(2160),
+        _ => None,
     }
 }
 

--- a/src/servarr/servarr_tests.rs
+++ b/src/servarr/servarr_tests.rs
@@ -74,6 +74,23 @@ mod tests {
     }
 
     #[test]
+    fn resolve_output_path_updates_fallout_style_downscale_quality() {
+        let base = PathBuf::from("Fallout - S02E06 - The Other Player WEBDL-2160p.mkv");
+        let resolved = resolve_output_path(&base, "mp4", ".fixed", VideoQuality::P480).unwrap();
+        assert_eq!(
+            resolved,
+            PathBuf::from("Fallout - S02E06 - The Other Player WEBDL-480p.fixed.mp4")
+        );
+    }
+
+    #[test]
+    fn resolve_output_path_does_not_relabel_upward() {
+        let base = PathBuf::from("Show.S01E01.480p.WEB-DL.mkv");
+        let resolved = resolve_output_path(&base, "mp4", ".fixed", VideoQuality::P2160).unwrap();
+        assert_eq!(resolved, PathBuf::from("Show.S01E01.480p.WEB-DL.fixed.mp4"));
+    }
+
+    #[test]
     fn resolve_media_path_uses_sonarr_fallback() {
         let _guard = ENV_MUTEX.lock().unwrap();
         env::remove_var("sonarr_episodefile_path");

--- a/src/servarr/servarr_tests.rs
+++ b/src/servarr/servarr_tests.rs
@@ -74,12 +74,12 @@ mod tests {
     }
 
     #[test]
-    fn resolve_output_path_updates_fallout_style_downscale_quality() {
-        let base = PathBuf::from("Fallout - S02E06 - The Other Player WEBDL-2160p.mkv");
+    fn resolve_output_path_updates_source_quality_on_downscale() {
+        let base = PathBuf::from("Example Show - S01E02 - Example Episode WEBDL-2160p.mkv");
         let resolved = resolve_output_path(&base, "mp4", ".fixed", VideoQuality::P480).unwrap();
         assert_eq!(
             resolved,
-            PathBuf::from("Fallout - S02E06 - The Other Player WEBDL-480p.fixed.mp4")
+            PathBuf::from("Example Show - S01E02 - Example Episode WEBDL-480p.fixed.mp4")
         );
     }
 

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -900,7 +900,7 @@ mod tests {
         args.video_quality = VideoQuality::MatchSource;
         args.streaming_devices = Some(vec![StreamingDeviceSelection::All]);
 
-        assert_eq!(servarr_filename_video_quality(&args), VideoQuality::P480);
+        assert_eq!(servarr_filename_video_quality(&args), VideoQuality::P720);
     }
 
     #[test]

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -260,7 +260,7 @@ fn prepare_servarr(args: &Args) -> Result<IntegrationPreparation> {
         has_output: args.output_file.is_some(),
         desired_extension: &args.servarr_output_extension,
         desired_suffix: &args.servarr_output_suffix,
-        desired_video_quality: args.video_quality,
+        desired_video_quality: servarr_filename_video_quality(args),
         language_requirements: servarr::LanguageRequirements {
             enabled: args.servarr_language_check,
             audio: servarr::parse_language_list(args.required_audio_languages.as_deref()),
@@ -277,6 +277,56 @@ fn prepare_servarr(args: &Args) -> Result<IntegrationPreparation> {
         },
     };
     servarr::prepare_from_env(servarr_view)
+}
+
+/// Computes the quality token Servarr replacement paths should use.
+///
+/// Explicit `--video-quality` values win; otherwise, mirror the effective
+/// device-cap quality so downscaled replacements do not keep a misleading
+/// source-resolution filename token.
+fn servarr_filename_video_quality(args: &Args) -> crate::transcoder::VideoQuality {
+    use crate::devices::Resolution;
+    use crate::transcoder::VideoQuality;
+
+    if args.video_quality != VideoQuality::MatchSource {
+        return args.video_quality;
+    }
+
+    let selections = args
+        .streaming_devices
+        .clone()
+        .unwrap_or_else(|| vec![StreamingDeviceSelection::All]);
+
+    let mut streaming_devices: Vec<&StreamingDevice> = if selections
+        .iter()
+        .any(|selection| matches!(selection, StreamingDeviceSelection::All))
+    {
+        devices::STREAMING_DEVICES.iter().collect()
+    } else {
+        selections
+            .into_iter()
+            .flat_map(|selection| match selection {
+                StreamingDeviceSelection::Model(device) => vec![device],
+                StreamingDeviceSelection::Family(family) => devices::devices_for_family(family),
+                StreamingDeviceSelection::All => Vec::new(),
+            })
+            .collect()
+    };
+
+    streaming_devices.sort_by_key(|device| device.model);
+    streaming_devices.dedup_by_key(|device| device.model);
+
+    let Ok(resolved_profile) = devices::resolve_target_profile(&streaming_devices) else {
+        return VideoQuality::MatchSource;
+    };
+
+    match resolved_profile.max_resolution {
+        Resolution::Resolution480p => VideoQuality::P480,
+        Resolution::Resolution720p => VideoQuality::P720,
+        Resolution::Resolution1080p => VideoQuality::P1080,
+        Resolution::Resolution1440p => VideoQuality::P1440,
+        Resolution::Resolution2160p => VideoQuality::P2160,
+    }
 }
 
 /// Logs Servarr-related environment context for replacement/batch runs.
@@ -820,6 +870,8 @@ fn ocr_multi_gpu_requested() -> bool {
 mod tests {
     use super::*;
     use crate::servarr::IntegrationKind;
+    use crate::transcoder::VideoQuality;
+    use clap::Parser;
     use std::ffi::CString;
     use std::path::PathBuf;
 
@@ -840,6 +892,24 @@ mod tests {
             temp_output_path,
             backup_path,
         }
+    }
+
+    #[test]
+    fn servarr_filename_video_quality_uses_all_device_cap_for_match_source() {
+        let mut args = Args::parse_from(["direct_play_nice"]);
+        args.video_quality = VideoQuality::MatchSource;
+        args.streaming_devices = Some(vec![StreamingDeviceSelection::All]);
+
+        assert_eq!(servarr_filename_video_quality(&args), VideoQuality::P480);
+    }
+
+    #[test]
+    fn servarr_filename_video_quality_prefers_explicit_video_quality() {
+        let mut args = Args::parse_from(["direct_play_nice"]);
+        args.video_quality = VideoQuality::P720;
+        args.streaming_devices = Some(vec![StreamingDeviceSelection::All]);
+
+        assert_eq!(servarr_filename_video_quality(&args), VideoQuality::P720);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- derive Servarr replacement filename quality from the effective device resolution cap when `video_quality=match-source`
- keep explicit `video_quality` behavior unchanged
- prevent upward filename relabeling, so a lower-quality source is not renamed to a higher quality just because the device cap allows it
- add regression coverage for source-quality downscales and app-entry tests for device-cap filename quality

Fixes #147.

## Testing

- `cargo fmt`
- `cargo check`
- `git diff --check`
- `cargo test servarr::servarr_tests` *(blocked by workspace linker issue: undefined references from vcpkg static `libpng`/`libfontconfig` to zlib/freetype symbols)*
- `cargo test transcoder::app_entry::tests` *(same linker issue)*
- Manual integration smoke test on a disposable media copy: verified a 2160p-labeled source downscaled to 480p plans and writes a `WEBDL-480p.fixed.mp4` replacement; output validated with `ffmpeg`.
