### PR TITLE
Enable default output validation and visual checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ skip_codec_check = false
 validate_output = true
 visual_validate_output = true
 visual_quality_report = false
+visual_scan_frames = 120
+visual_sample_interval = 15
+visual_failure_ratio = 0.60
 
 # Optional: require imported media to contain English audio.
 # Start with dry-run while tuning candidate policy and custom formats.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ ocr_engine = "pp-ocr-v4"
 ocr_format = "srt"
 ocr_write_srt_sidecar = false
 skip_codec_check = false
+# Output validation is enabled by default; keep these explicit in Servarr mode
+# if you want config-visible safety settings.
+validate_output = true
+visual_validate_output = true
+visual_quality_report = false
 
 # Optional: require imported media to contain English audio.
 # Start with dry-run while tuning candidate policy and custom formats.

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -19,9 +19,9 @@ packet loop.
 6. Optional OCR post-processing handles bitmap subtitles and remuxes generated
    text subtitles into the final output.
 7. Post-write verification checks H.264 constraints. Output validation is
-   enabled by default: the final media file is reopened to verify expected stream
-   codecs, stream hygiene, temporal consistency, and sampled visual statistics
-   for obvious corruption such as repeated green-screen frames.
+   enabled by default: the final media file is reopened to verify expected
+   stream codecs, stream hygiene, temporal consistency, and sampled visual
+   statistics for obvious corruption such as repeated green-screen frames.
 
 ## FFmpeg Boundaries
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -18,9 +18,10 @@ packet loop.
    muxed through separate stream-processing paths.
 6. Optional OCR post-processing handles bitmap subtitles and remuxes generated
    text subtitles into the final output.
-7. Post-write verification checks H.264 constraints, and `--validate-output`
-   can reopen the final media file to verify expected stream codecs and stream
-   hygiene.
+7. Post-write verification checks H.264 constraints. Output validation is
+   enabled by default: the final media file is reopened to verify expected stream
+   codecs, stream hygiene, temporal consistency, and sampled visual statistics
+   for obvious corruption such as repeated green-screen frames.
 
 ## FFmpeg Boundaries
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -22,6 +22,9 @@ packet loop.
    enabled by default: the final media file is reopened to verify expected
    stream codecs, stream hygiene, temporal consistency, and sampled visual
    statistics for obvious corruption such as repeated green-screen frames.
+   The visual layer exists because a file can decode cleanly and still look
+   dangerously wrong to users. Operators can tune how many frames are scanned,
+   how often samples are inspected, and what sampled corruption ratio fails.
 
 ## FFmpeg Boundaries
 

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -37,6 +37,12 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
   structural validation enabled
 - `--visual-quality-report` log sampled luma/chroma statistics for
   troubleshooting scaling or visual-corruption issues
+- `--visual-scan-frames <N>` set how many decoded video frames visual
+  validation scans before deciding the output is safe enough to promote
+- `--visual-sample-interval <N>` inspect every Nth decoded frame during visual
+  validation; default is 15
+- `--visual-failure-ratio <R>` set the sampled-frame fraction that must look
+  corrupt before visual validation fails; default is 0.60
 
 ## Hardware controls
 

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -29,7 +29,14 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--primary-video-criteria <primary_video_criteria>` `resolution|bitrate|fps`
 - `--skip-codec-check`
 - `--validate-output` reopen the completed output and fail if expected A/V
-  codecs or stream hygiene checks do not pass
+  codecs, stream hygiene, or temporal consistency checks do not pass (enabled by default)
+- `--no-validate-output` disable post-conversion output validation
+- `--visual-validate-output` decode sampled output frames and fail on obvious
+  visual corruption such as repeated green-screen frames (enabled by default)
+- `--no-visual-validate-output` disable sampled visual validation while keeping
+  structural validation enabled
+- `--visual-quality-report` log sampled luma/chroma statistics for troubleshooting
+  scaling or visual-corruption issues
 
 ## Hardware controls
 

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -29,14 +29,14 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--primary-video-criteria <primary_video_criteria>` `resolution|bitrate|fps`
 - `--skip-codec-check`
 - `--validate-output` reopen the completed output and fail if expected A/V
-  codecs, stream hygiene, or temporal consistency checks do not pass (enabled by default)
+  codecs, stream hygiene, or temporal checks fail (enabled by default)
 - `--no-validate-output` disable post-conversion output validation
 - `--visual-validate-output` decode sampled output frames and fail on obvious
   visual corruption such as repeated green-screen frames (enabled by default)
 - `--no-visual-validate-output` disable sampled visual validation while keeping
   structural validation enabled
-- `--visual-quality-report` log sampled luma/chroma statistics for troubleshooting
-  scaling or visual-corruption issues
+- `--visual-quality-report` log sampled luma/chroma statistics for
+  troubleshooting scaling or visual-corruption issues
 
 ## Hardware controls
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,9 @@ pub struct Config {
     pub ocr_external_command: Option<String>,
     pub ocr_write_srt_sidecar: Option<bool>,
     pub skip_codec_check: Option<bool>,
+    pub validate_output: Option<bool>,
+    pub visual_validate_output: Option<bool>,
+    pub visual_quality_report: Option<bool>,
     pub delete_source: Option<bool>,
     pub plex: Option<PlexSettings>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,9 @@ pub struct Config {
     pub validate_output: Option<bool>,
     pub visual_validate_output: Option<bool>,
     pub visual_quality_report: Option<bool>,
+    pub visual_scan_frames: Option<usize>,
+    pub visual_sample_interval: Option<usize>,
+    pub visual_failure_ratio: Option<f64>,
     pub delete_source: Option<bool>,
     pub plex: Option<PlexSettings>,
 }

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -293,6 +293,24 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "visual_scan_frames") {
+        if let Some(visual_scan_frames) = cfg.visual_scan_frames {
+            args.visual_scan_frames = visual_scan_frames;
+        }
+    }
+
+    if !cli_value_provided(matches, "visual_sample_interval") {
+        if let Some(visual_sample_interval) = cfg.visual_sample_interval {
+            args.visual_sample_interval = visual_sample_interval;
+        }
+    }
+
+    if !cli_value_provided(matches, "visual_failure_ratio") {
+        if let Some(visual_failure_ratio) = cfg.visual_failure_ratio {
+            args.visual_failure_ratio = visual_failure_ratio;
+        }
+    }
+
     if args.delete_source.is_none() {
         if let Some(delete_source) = cfg.delete_source {
             args.delete_source = Some(delete_source);
@@ -303,6 +321,9 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ffmpeg_utils::{
+        DEFAULT_VISUAL_FAILURE_RATIO, DEFAULT_VISUAL_SAMPLE_INTERVAL, DEFAULT_VISUAL_SCAN_FRAMES,
+    };
     use crate::transcoder::quality::VideoQuality;
     use crate::{ResizeBackend, ResizeQuality, SubtitleFailurePolicy};
     use clap::{CommandFactory, FromArgMatches};
@@ -443,21 +464,30 @@ mod tests {
         assert!(args.validate_output);
         assert!(args.visual_validate_output);
         assert!(!args.visual_quality_report);
+        assert_eq!(args.visual_scan_frames, DEFAULT_VISUAL_SCAN_FRAMES);
+        assert_eq!(args.visual_sample_interval, DEFAULT_VISUAL_SAMPLE_INTERVAL);
+        assert_eq!(args.visual_failure_ratio, DEFAULT_VISUAL_FAILURE_RATIO);
     }
 
     #[test]
-    fn config_can_disable_default_output_validation_when_cli_is_absent() {
+    fn config_can_override_default_output_validation_when_cli_is_absent() {
         let (mut args, matches) = parse_args(&["direct_play_nice"]);
         let cfg = config::Config {
             validate_output: Some(false),
             visual_validate_output: Some(false),
             visual_quality_report: Some(true),
+            visual_scan_frames: Some(240),
+            visual_sample_interval: Some(10),
+            visual_failure_ratio: Some(0.40),
             ..Default::default()
         };
         apply_config_overrides(&mut args, &cfg, &matches);
         assert!(!args.validate_output);
         assert!(!args.visual_validate_output);
         assert!(args.visual_quality_report);
+        assert_eq!(args.visual_scan_frames, 240);
+        assert_eq!(args.visual_sample_interval, 10);
+        assert_eq!(args.visual_failure_ratio, 0.40);
     }
 
     #[test]
@@ -466,15 +496,27 @@ mod tests {
             "direct_play_nice",
             "--validate-output",
             "--visual-validate-output",
+            "--visual-scan-frames",
+            "180",
+            "--visual-sample-interval",
+            "12",
+            "--visual-failure-ratio",
+            "0.50",
         ]);
         let cfg = config::Config {
             validate_output: Some(false),
             visual_validate_output: Some(false),
+            visual_scan_frames: Some(240),
+            visual_sample_interval: Some(10),
+            visual_failure_ratio: Some(0.40),
             ..Default::default()
         };
         apply_config_overrides(&mut args, &cfg, &matches);
         assert!(args.validate_output);
         assert!(args.visual_validate_output);
+        assert_eq!(args.visual_scan_frames, 180);
+        assert_eq!(args.visual_sample_interval, 12);
+        assert_eq!(args.visual_failure_ratio, 0.50);
     }
 
     #[test]

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -271,6 +271,28 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if cli_value_provided(matches, "no_validate_output") && args.no_validate_output {
+        args.validate_output = false;
+    } else if !cli_value_provided(matches, "validate_output") {
+        if let Some(validate_output) = cfg.validate_output {
+            args.validate_output = validate_output;
+        }
+    }
+
+    if cli_value_provided(matches, "no_visual_validate_output") && args.no_visual_validate_output {
+        args.visual_validate_output = false;
+    } else if !cli_value_provided(matches, "visual_validate_output") {
+        if let Some(visual_validate_output) = cfg.visual_validate_output {
+            args.visual_validate_output = visual_validate_output;
+        }
+    }
+
+    if !cli_value_provided(matches, "visual_quality_report") {
+        if let Some(visual_quality_report) = cfg.visual_quality_report {
+            args.visual_quality_report = visual_quality_report;
+        }
+    }
+
     if args.delete_source.is_none() {
         if let Some(delete_source) = cfg.delete_source {
             args.delete_source = Some(delete_source);
@@ -413,6 +435,63 @@ mod tests {
             args.subtitle_failure_policy,
             SubtitleFailurePolicy::SkipStream
         );
+    }
+
+    #[test]
+    fn validation_defaults_are_enabled() {
+        let (args, _matches) = parse_args(&["direct_play_nice"]);
+        assert!(args.validate_output);
+        assert!(args.visual_validate_output);
+        assert!(!args.visual_quality_report);
+    }
+
+    #[test]
+    fn config_can_disable_default_output_validation_when_cli_is_absent() {
+        let (mut args, matches) = parse_args(&["direct_play_nice"]);
+        let cfg = config::Config {
+            validate_output: Some(false),
+            visual_validate_output: Some(false),
+            visual_quality_report: Some(true),
+            ..Default::default()
+        };
+        apply_config_overrides(&mut args, &cfg, &matches);
+        assert!(!args.validate_output);
+        assert!(!args.visual_validate_output);
+        assert!(args.visual_quality_report);
+    }
+
+    #[test]
+    fn cli_validation_flags_take_precedence_over_config() {
+        let (mut args, matches) = parse_args(&[
+            "direct_play_nice",
+            "--validate-output",
+            "--visual-validate-output",
+        ]);
+        let cfg = config::Config {
+            validate_output: Some(false),
+            visual_validate_output: Some(false),
+            ..Default::default()
+        };
+        apply_config_overrides(&mut args, &cfg, &matches);
+        assert!(args.validate_output);
+        assert!(args.visual_validate_output);
+    }
+
+    #[test]
+    fn no_validation_flags_disable_default_validation() {
+        let (mut args, matches) = parse_args(&[
+            "direct_play_nice",
+            "--no-validate-output",
+            "--no-visual-validate-output",
+        ]);
+        let cfg = config::Config {
+            validate_output: Some(true),
+            visual_validate_output: Some(true),
+            ..Default::default()
+        };
+        apply_config_overrides(&mut args, &cfg, &matches);
+        assert!(!args.validate_output);
+        assert!(!args.visual_validate_output);
     }
 
     #[test]

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -369,13 +369,45 @@ pub(crate) struct Args {
     )]
     pub(crate) skip_codec_check: bool,
 
-    /// Reopen the produced media file and verify expected stream codecs before reporting success.
+    /// Reopen and structurally validate the produced media file before reporting success (default: enabled).
     #[arg(
         long = "validate-output",
-        default_value_t = false,
+        default_value_t = true,
         id = "validate_output"
     )]
     pub(crate) validate_output: bool,
+
+    /// Disable post-conversion structural output validation.
+    #[arg(
+        long = "no-validate-output",
+        default_value_t = false,
+        id = "no_validate_output"
+    )]
+    pub(crate) no_validate_output: bool,
+
+    /// Decode sampled output frames and reject obvious visual corruption such as green/solid frames (default: enabled).
+    #[arg(
+        long = "visual-validate-output",
+        default_value_t = true,
+        id = "visual_validate_output"
+    )]
+    pub(crate) visual_validate_output: bool,
+
+    /// Disable sampled visual output validation.
+    #[arg(
+        long = "no-visual-validate-output",
+        default_value_t = false,
+        id = "no_visual_validate_output"
+    )]
+    pub(crate) no_visual_validate_output: bool,
+
+    /// Log sampled output-frame visual statistics for troubleshooting scaling/corruption issues.
+    #[arg(
+        long = "visual-quality-report",
+        default_value_t = false,
+        id = "visual_quality_report"
+    )]
+    pub(crate) visual_quality_report: bool,
 
     /// Delete the source file after a successful conversion for direct CLI runs.
     /// In Sonarr/Radarr integration mode, successful replacement always removes the original while failures restore it.

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -23,6 +23,10 @@ use crate::types::{
 
 pub(crate) use crate::cli::progress::ProgressTracker;
 
+pub(crate) const DEFAULT_VISUAL_SCAN_FRAMES: usize = 120;
+pub(crate) const DEFAULT_VISUAL_SAMPLE_INTERVAL: usize = 15;
+pub(crate) const DEFAULT_VISUAL_FAILURE_RATIO: f64 = 0.60;
+
 // TODO: switch to enum to allow for different modes
 // see: https://github.com/clap-rs/clap/discussions/3711#discussioncomment-2717657
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -408,6 +412,30 @@ pub(crate) struct Args {
         id = "visual_quality_report"
     )]
     pub(crate) visual_quality_report: bool,
+
+    /// Number of decoded video frames to scan during visual output validation.
+    #[arg(
+        long = "visual-scan-frames",
+        default_value_t = DEFAULT_VISUAL_SCAN_FRAMES,
+        id = "visual_scan_frames"
+    )]
+    pub(crate) visual_scan_frames: usize,
+
+    /// Decode interval for sampled visual checks; 15 inspects frames 0, 15, 30, etc.
+    #[arg(
+        long = "visual-sample-interval",
+        default_value_t = DEFAULT_VISUAL_SAMPLE_INTERVAL,
+        id = "visual_sample_interval"
+    )]
+    pub(crate) visual_sample_interval: usize,
+
+    /// Fraction of sampled frames that must look corrupt before visual validation fails.
+    #[arg(
+        long = "visual-failure-ratio",
+        default_value_t = DEFAULT_VISUAL_FAILURE_RATIO,
+        id = "visual_failure_ratio"
+    )]
+    pub(crate) visual_failure_ratio: f64,
 
     /// Delete the source file after a successful conversion for direct CLI runs.
     /// In Sonarr/Radarr integration mode, successful replacement always removes the original while failures restore it.

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -30,7 +30,7 @@ use crate::transcoder::h264::{DecoderError, HwEncoderInitError, HwProfileLevelMi
 use crate::transcoder::helpers::{describe_bitrate, describe_resolution, devices_support_codec};
 use crate::transcoder::pipeline::{assess_direct_play_compatibility, DirectPlayConstraints};
 use crate::transcoder::quality::{QualityLimits, VideoCodecPreference};
-use crate::transcoder::verification::validate_output_file;
+use crate::transcoder::verification::{validate_output_file, OutputValidationOptions};
 use crate::transcoder::ConversionOutcome;
 use crate::types::{OcrFormat, OutputFormat};
 
@@ -761,6 +761,10 @@ fn run_conversion(
             output_file,
             target_video_codec,
             common_audio_codec,
+            OutputValidationOptions {
+                visual_validate: args.visual_validate_output,
+                visual_quality_report: args.visual_quality_report,
+            },
         ) {
             conversion_result = Err(err);
         }

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -764,6 +764,9 @@ fn run_conversion(
             OutputValidationOptions {
                 visual_validate: args.visual_validate_output,
                 visual_quality_report: args.visual_quality_report,
+                visual_scan_frames: args.visual_scan_frames,
+                visual_sample_interval: args.visual_sample_interval,
+                visual_failure_ratio: args.visual_failure_ratio,
             },
         ) {
             conversion_result = Err(err);

--- a/src/transcoder/verification.rs
+++ b/src/transcoder/verification.rs
@@ -385,7 +385,7 @@ fn drain_visual_frames(
                     }
                 }
             }
-            Err(RsmpegError::DecoderDrainError) => break,
+            Err(RsmpegError::DecoderDrainError | RsmpegError::DecoderFlushedError) => break,
             Err(err) if is_eagain_error(&err) => break,
             Err(err) => {
                 bail!("Output visual validation failed: decoder receive_frame failed: {err}")

--- a/src/transcoder/verification.rs
+++ b/src/transcoder/verification.rs
@@ -14,20 +14,58 @@ use rsmpeg::avformat::{AVFormatContextInput, AVStreamRef};
 use rsmpeg::error::RsmpegError;
 use rsmpeg::ffi;
 
-use crate::ffmpeg_utils::is_eagain_error;
+use crate::ffmpeg_utils::{
+    is_eagain_error, DEFAULT_VISUAL_FAILURE_RATIO, DEFAULT_VISUAL_SAMPLE_INTERVAL,
+    DEFAULT_VISUAL_SCAN_FRAMES,
+};
 use crate::transcoder::helpers::{describe_codec, enable_strict_decode_failure};
 use crate::transcoder::pipeline_assessment::rational_to_f64;
 
 const MIN_SOURCE_FPS_FOR_COLLAPSE_CHECK: f64 = 10.0;
 const MIN_OUTPUT_DURATION_RATIO_FOR_COLLAPSE_CHECK: f64 = 0.90;
 const MIN_OUTPUT_FPS_RATIO: f64 = 0.80;
-const VISUAL_FRAMES_TO_SCAN: usize = 120;
-const VISUAL_SAMPLE_INTERVAL: usize = 15;
+const VISUAL_MIN_INSPECTED_FRAMES: usize = 3;
+const VISUAL_MIN_SUSPICIOUS_FRAMES: usize = 2;
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct OutputValidationOptions {
     pub(crate) visual_validate: bool,
     pub(crate) visual_quality_report: bool,
+    pub(crate) visual_scan_frames: usize,
+    pub(crate) visual_sample_interval: usize,
+    pub(crate) visual_failure_ratio: f64,
+}
+
+impl Default for OutputValidationOptions {
+    fn default() -> Self {
+        Self {
+            visual_validate: false,
+            visual_quality_report: false,
+            visual_scan_frames: DEFAULT_VISUAL_SCAN_FRAMES,
+            visual_sample_interval: DEFAULT_VISUAL_SAMPLE_INTERVAL,
+            visual_failure_ratio: DEFAULT_VISUAL_FAILURE_RATIO,
+        }
+    }
+}
+
+impl OutputValidationOptions {
+    fn validate_visual_settings(self) -> Result<()> {
+        if self.visual_scan_frames == 0 {
+            bail!("Output visual validation failed: visual_scan_frames must be greater than 0");
+        }
+        if self.visual_sample_interval == 0 {
+            bail!("Output visual validation failed: visual_sample_interval must be greater than 0");
+        }
+        if !self.visual_failure_ratio.is_finite()
+            || self.visual_failure_ratio <= 0.0
+            || self.visual_failure_ratio > 1.0
+        {
+            bail!(
+                "Output visual validation failed: visual_failure_ratio must be greater than 0 and at most 1"
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Reopens the completed output and verifies the minimum stream contract the
@@ -99,12 +137,8 @@ pub(crate) fn validate_output_file(
     validate_video_temporal_consistency(&input_ctx, &output_ctx)?;
 
     if options.visual_validate || options.visual_quality_report {
-        validate_visual_output(
-            &mut output_ctx,
-            output_file,
-            options.visual_validate,
-            options.visual_quality_report,
-        )?;
+        options.validate_visual_settings()?;
+        validate_visual_output(&mut output_ctx, output_file, options)?;
     }
 
     info!(
@@ -249,20 +283,22 @@ impl VisualInspectionReport {
         (self.inspected_frames > 0).then_some(self.luma_stddev_sum / self.inspected_frames as f64)
     }
 
-    fn green_failure_threshold(&self) -> usize {
-        ((self.inspected_frames as f64) * 0.60).ceil().max(2.0) as usize
+    fn green_failure_threshold(&self, failure_ratio: f64) -> usize {
+        ((self.inspected_frames as f64) * failure_ratio)
+            .ceil()
+            .max(VISUAL_MIN_SUSPICIOUS_FRAMES as f64) as usize
     }
 
-    fn green_failure(&self) -> bool {
-        self.inspected_frames >= 3 && self.suspicious_green_frames >= self.green_failure_threshold()
+    fn green_failure(&self, failure_ratio: f64) -> bool {
+        self.inspected_frames >= VISUAL_MIN_INSPECTED_FRAMES
+            && self.suspicious_green_frames >= self.green_failure_threshold(failure_ratio)
     }
 }
 
 fn validate_visual_output(
     output_ctx: &mut AVFormatContextInput,
     output_file: &CStr,
-    fail_on_corruption: bool,
-    force_report: bool,
+    options: OutputValidationOptions,
 ) -> Result<()> {
     let (video_stream_index, video_time_base, mut decode_ctx, decoder_name) = {
         let video_stream = output_ctx
@@ -298,7 +334,7 @@ fn validate_visual_output(
     let mut report = VisualInspectionReport::default();
     let mut video_packets_seen = 0usize;
 
-    while report.decoded_frames < VISUAL_FRAMES_TO_SCAN {
+    while report.decoded_frames < options.visual_scan_frames {
         let Some(mut packet) = output_ctx.read_packet()? else {
             break;
         };
@@ -314,7 +350,7 @@ fn validate_visual_output(
                 bail!("Output visual validation failed: decoder send_packet failed: {err}");
             }
         }
-        drain_visual_frames(&mut decode_ctx, &mut report)?;
+        drain_visual_frames(&mut decode_ctx, &mut report, options.visual_sample_interval)?;
     }
 
     match decode_ctx.send_packet(None) {
@@ -322,28 +358,36 @@ fn validate_visual_output(
         Err(err) if is_eagain_error(&err) => {}
         Err(err) => bail!("Output visual validation failed: decoder flush failed: {err}"),
     }
-    drain_visual_frames(&mut decode_ctx, &mut report)?;
+    drain_visual_frames(&mut decode_ctx, &mut report, options.visual_sample_interval)?;
 
     if report.decoded_frames == 0 && video_packets_seen > 0 {
         bail!("Output visual validation failed: no video frames decoded from output");
     }
 
-    if fail_on_corruption && report.green_failure() {
+    if options.visual_validate && report.green_failure(options.visual_failure_ratio) {
         bail!(
-            "Output visual validation failed: {} of {} sampled frames look like green-screen corruption in '{}'",
+            "Output visual validation failed: {} of {} sampled frames look like green-screen corruption in '{}' (threshold ratio {:.2})",
             report.suspicious_green_frames,
             report.inspected_frames,
-            output_file.to_string_lossy()
+            output_file.to_string_lossy(),
+            options.visual_failure_ratio
         );
     }
 
-    if force_report || report.suspicious_green_frames > 0 || report.near_solid_nonblack_frames > 0 {
+    if options.visual_quality_report
+        || report.suspicious_green_frames > 0
+        || report.near_solid_nonblack_frames > 0
+    {
         info!(
-            "Output visual quality report for '{}': decoder={}, decoded_frames={}, inspected_frames={}, suspicious_green_frames={}, near_solid_nonblack_frames={}, avg_luma_mean={}, avg_luma_stddev={}",
+            "Output visual quality report for '{}': decoder={}, decoded_frames={}, inspected_frames={}, scan_frames={}, sample_interval={}, failure_ratio={:.2}, suspicious_green_threshold={}, suspicious_green_frames={}, near_solid_nonblack_frames={}, avg_luma_mean={}, avg_luma_stddev={}",
             output_file.to_string_lossy(),
             decoder_name,
             report.decoded_frames,
             report.inspected_frames,
+            options.visual_scan_frames,
+            options.visual_sample_interval,
+            options.visual_failure_ratio,
+            report.green_failure_threshold(options.visual_failure_ratio),
             report.suspicious_green_frames,
             report.near_solid_nonblack_frames,
             format_optional_f64(report.average_luma_mean()),
@@ -351,11 +395,14 @@ fn validate_visual_output(
         );
     } else {
         debug!(
-            "Output visual validation passed for '{}' (decoder={}, decoded_frames={}, inspected_frames={}).",
+            "Output visual validation passed for '{}' (decoder={}, decoded_frames={}, inspected_frames={}, scan_frames={}, sample_interval={}, failure_ratio={:.2}).",
             output_file.to_string_lossy(),
             decoder_name,
             report.decoded_frames,
-            report.inspected_frames
+            report.inspected_frames,
+            options.visual_scan_frames,
+            options.visual_sample_interval,
+            options.visual_failure_ratio
         );
     }
 
@@ -373,13 +420,14 @@ fn validate_visual_output(
 fn drain_visual_frames(
     decode_ctx: &mut AVCodecContext,
     report: &mut VisualInspectionReport,
+    sample_interval: usize,
 ) -> Result<()> {
     loop {
         match decode_ctx.receive_frame() {
             Ok(frame) => {
                 let frame_index = report.decoded_frames;
                 report.record_decoded_frame();
-                if frame_index.is_multiple_of(VISUAL_SAMPLE_INTERVAL) {
+                if frame_index.is_multiple_of(sample_interval) {
                     if let Some(stats) = frame_visual_stats(&frame) {
                         report.record_stats(stats);
                     }
@@ -668,14 +716,62 @@ mod tests {
         report.record_stats(green);
         report.record_stats(normal);
 
-        assert!(report.green_failure());
+        assert!(report.green_failure(DEFAULT_VISUAL_FAILURE_RATIO));
 
         let mut mostly_normal = VisualInspectionReport::default();
         mostly_normal.record_stats(green);
         mostly_normal.record_stats(normal);
         mostly_normal.record_stats(normal);
 
-        assert!(!mostly_normal.green_failure());
+        assert!(!mostly_normal.green_failure(DEFAULT_VISUAL_FAILURE_RATIO));
+    }
+
+    #[test]
+    fn visual_failure_ratio_controls_green_failure_threshold() {
+        let mut report = VisualInspectionReport::default();
+        let green = FrameVisualStats {
+            luma_mean: 145.0,
+            luma_stddev: 4.0,
+            chroma_u_mean: Some(54.0),
+            chroma_v_mean: Some(34.0),
+        };
+        let normal = FrameVisualStats {
+            luma_mean: 110.0,
+            luma_stddev: 40.0,
+            chroma_u_mean: Some(128.0),
+            chroma_v_mean: Some(128.0),
+        };
+
+        report.record_stats(green);
+        report.record_stats(green);
+        report.record_stats(normal);
+        report.record_stats(normal);
+        report.record_stats(normal);
+
+        assert!(!report.green_failure(DEFAULT_VISUAL_FAILURE_RATIO));
+        assert!(report.green_failure(0.40));
+    }
+
+    #[test]
+    fn visual_options_reject_invalid_amounts_and_ratios() {
+        assert!(OutputValidationOptions {
+            visual_scan_frames: 0,
+            ..Default::default()
+        }
+        .validate_visual_settings()
+        .is_err());
+        assert!(OutputValidationOptions {
+            visual_sample_interval: 0,
+            ..Default::default()
+        }
+        .validate_visual_settings()
+        .is_err());
+        assert!(OutputValidationOptions {
+            visual_failure_ratio: 1.5,
+            ..Default::default()
+        }
+        .validate_visual_settings()
+        .is_err());
     }
 
     #[test]

--- a/src/transcoder/verification.rs
+++ b/src/transcoder/verification.rs
@@ -7,17 +7,28 @@
 
 use std::ffi::CStr;
 
-use anyhow::{bail, Context, Result};
-use log::info;
+use anyhow::{anyhow, bail, Context, Result};
+use log::{debug, info, warn};
+use rsmpeg::avcodec::{AVCodec, AVCodecContext};
 use rsmpeg::avformat::{AVFormatContextInput, AVStreamRef};
+use rsmpeg::error::RsmpegError;
 use rsmpeg::ffi;
 
-use crate::transcoder::helpers::describe_codec;
+use crate::ffmpeg_utils::is_eagain_error;
+use crate::transcoder::helpers::{describe_codec, enable_strict_decode_failure};
 use crate::transcoder::pipeline_assessment::rational_to_f64;
 
 const MIN_SOURCE_FPS_FOR_COLLAPSE_CHECK: f64 = 10.0;
 const MIN_OUTPUT_DURATION_RATIO_FOR_COLLAPSE_CHECK: f64 = 0.90;
 const MIN_OUTPUT_FPS_RATIO: f64 = 0.80;
+const VISUAL_FRAMES_TO_SCAN: usize = 120;
+const VISUAL_SAMPLE_INTERVAL: usize = 15;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct OutputValidationOptions {
+    pub(crate) visual_validate: bool,
+    pub(crate) visual_quality_report: bool,
+}
 
 /// Reopens the completed output and verifies the minimum stream contract the
 /// converter promised: a primary video stream with the requested codec, a
@@ -28,10 +39,11 @@ pub(crate) fn validate_output_file(
     output_file: &CStr,
     expected_video_codec: ffi::AVCodecID,
     expected_audio_codec: ffi::AVCodecID,
+    options: OutputValidationOptions,
 ) -> Result<()> {
     let input_ctx = AVFormatContextInput::open(input_file)
         .with_context(|| format!("Failed to reopen input '{}'", input_file.to_string_lossy()))?;
-    let output_ctx = AVFormatContextInput::open(output_file).with_context(|| {
+    let mut output_ctx = AVFormatContextInput::open(output_file).with_context(|| {
         format!(
             "Failed to reopen output '{}'",
             output_file.to_string_lossy()
@@ -85,6 +97,15 @@ pub(crate) fn validate_output_file(
     }
 
     validate_video_temporal_consistency(&input_ctx, &output_ctx)?;
+
+    if options.visual_validate || options.visual_quality_report {
+        validate_visual_output(
+            &mut output_ctx,
+            output_file,
+            options.visual_validate,
+            options.visual_quality_report,
+        )?;
+    }
 
     info!(
         "Output validation passed for '{}'.",
@@ -167,6 +188,361 @@ fn fps_from_frame_count(frame_count: Option<i64>, duration_seconds: Option<f64>)
     (frame_count > 0 && duration_seconds > 0.0).then_some(frame_count as f64 / duration_seconds)
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct FrameVisualStats {
+    luma_mean: f64,
+    luma_stddev: f64,
+    chroma_u_mean: Option<f64>,
+    chroma_v_mean: Option<f64>,
+}
+
+impl FrameVisualStats {
+    fn suspicious_green_screen(self) -> bool {
+        let (Some(u), Some(v)) = (self.chroma_u_mean, self.chroma_v_mean) else {
+            return false;
+        };
+        let green_bias = (128.0 - u).max(0.0) + (128.0 - v).max(0.0);
+        self.luma_mean > 25.0
+            && self.luma_stddev < 55.0
+            && u < 100.0
+            && v < 115.0
+            && green_bias > 45.0
+    }
+
+    fn near_solid_nonblack(self) -> bool {
+        self.luma_mean > 25.0 && self.luma_mean < 235.0 && self.luma_stddev < 2.5
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct VisualInspectionReport {
+    decoded_frames: usize,
+    inspected_frames: usize,
+    suspicious_green_frames: usize,
+    near_solid_nonblack_frames: usize,
+    luma_mean_sum: f64,
+    luma_stddev_sum: f64,
+}
+
+impl VisualInspectionReport {
+    fn record_decoded_frame(&mut self) {
+        self.decoded_frames += 1;
+    }
+
+    fn record_stats(&mut self, stats: FrameVisualStats) {
+        self.inspected_frames += 1;
+        self.luma_mean_sum += stats.luma_mean;
+        self.luma_stddev_sum += stats.luma_stddev;
+        if stats.suspicious_green_screen() {
+            self.suspicious_green_frames += 1;
+        }
+        if stats.near_solid_nonblack() {
+            self.near_solid_nonblack_frames += 1;
+        }
+    }
+
+    fn average_luma_mean(&self) -> Option<f64> {
+        (self.inspected_frames > 0).then_some(self.luma_mean_sum / self.inspected_frames as f64)
+    }
+
+    fn average_luma_stddev(&self) -> Option<f64> {
+        (self.inspected_frames > 0).then_some(self.luma_stddev_sum / self.inspected_frames as f64)
+    }
+
+    fn green_failure_threshold(&self) -> usize {
+        ((self.inspected_frames as f64) * 0.60).ceil().max(2.0) as usize
+    }
+
+    fn green_failure(&self) -> bool {
+        self.inspected_frames >= 3 && self.suspicious_green_frames >= self.green_failure_threshold()
+    }
+}
+
+fn validate_visual_output(
+    output_ctx: &mut AVFormatContextInput,
+    output_file: &CStr,
+    fail_on_corruption: bool,
+    force_report: bool,
+) -> Result<()> {
+    let (video_stream_index, video_time_base, mut decode_ctx, decoder_name) = {
+        let video_stream = output_ctx
+            .streams()
+            .iter()
+            .find(|stream| stream.codecpar().codec_type == ffi::AVMEDIA_TYPE_VIDEO)
+            .ok_or_else(|| anyhow!("Output visual validation failed: no video stream"))?;
+        let codec_id = video_stream.codecpar().codec_id;
+        let decoder = AVCodec::find_decoder(codec_id).ok_or_else(|| {
+            anyhow!(
+                "Output visual validation failed: decoder unavailable for {}",
+                describe_codec(codec_id)
+            )
+        })?;
+        let decoder_name = decoder.name().to_string_lossy().into_owned();
+        let mut decode_ctx = AVCodecContext::new(&decoder);
+        decode_ctx
+            .apply_codecpar(&video_stream.codecpar())
+            .context("Output visual validation failed: applying video codec parameters")?;
+        decode_ctx.set_time_base(video_stream.time_base);
+        enable_strict_decode_failure(&mut decode_ctx);
+        decode_ctx.open(None).with_context(|| {
+            format!("Output visual validation failed: opening decoder '{decoder_name}'")
+        })?;
+        (
+            video_stream.index,
+            video_stream.time_base,
+            decode_ctx,
+            decoder_name,
+        )
+    };
+
+    let mut report = VisualInspectionReport::default();
+    let mut video_packets_seen = 0usize;
+
+    while report.decoded_frames < VISUAL_FRAMES_TO_SCAN {
+        let Some(mut packet) = output_ctx.read_packet()? else {
+            break;
+        };
+        if packet.stream_index != video_stream_index {
+            continue;
+        }
+        video_packets_seen += 1;
+        packet.rescale_ts(video_time_base, decode_ctx.time_base);
+        match decode_ctx.send_packet(Some(&packet)) {
+            Ok(_) | Err(RsmpegError::DecoderFlushedError) => {}
+            Err(err) if is_eagain_error(&err) => {}
+            Err(err) => {
+                bail!("Output visual validation failed: decoder send_packet failed: {err}");
+            }
+        }
+        drain_visual_frames(&mut decode_ctx, &mut report)?;
+    }
+
+    match decode_ctx.send_packet(None) {
+        Ok(_) | Err(RsmpegError::DecoderFlushedError) => {}
+        Err(err) if is_eagain_error(&err) => {}
+        Err(err) => bail!("Output visual validation failed: decoder flush failed: {err}"),
+    }
+    drain_visual_frames(&mut decode_ctx, &mut report)?;
+
+    if report.decoded_frames == 0 && video_packets_seen > 0 {
+        bail!("Output visual validation failed: no video frames decoded from output");
+    }
+
+    if fail_on_corruption && report.green_failure() {
+        bail!(
+            "Output visual validation failed: {} of {} sampled frames look like green-screen corruption in '{}'",
+            report.suspicious_green_frames,
+            report.inspected_frames,
+            output_file.to_string_lossy()
+        );
+    }
+
+    if force_report || report.suspicious_green_frames > 0 || report.near_solid_nonblack_frames > 0 {
+        info!(
+            "Output visual quality report for '{}': decoder={}, decoded_frames={}, inspected_frames={}, suspicious_green_frames={}, near_solid_nonblack_frames={}, avg_luma_mean={}, avg_luma_stddev={}",
+            output_file.to_string_lossy(),
+            decoder_name,
+            report.decoded_frames,
+            report.inspected_frames,
+            report.suspicious_green_frames,
+            report.near_solid_nonblack_frames,
+            format_optional_f64(report.average_luma_mean()),
+            format_optional_f64(report.average_luma_stddev())
+        );
+    } else {
+        debug!(
+            "Output visual validation passed for '{}' (decoder={}, decoded_frames={}, inspected_frames={}).",
+            output_file.to_string_lossy(),
+            decoder_name,
+            report.decoded_frames,
+            report.inspected_frames
+        );
+    }
+
+    if report.inspected_frames == 0 && report.decoded_frames > 0 {
+        warn!(
+            "Output visual validation decoded {} frame(s) from '{}' but could not inspect pixel statistics for the decoded format.",
+            report.decoded_frames,
+            output_file.to_string_lossy()
+        );
+    }
+
+    Ok(())
+}
+
+fn drain_visual_frames(
+    decode_ctx: &mut AVCodecContext,
+    report: &mut VisualInspectionReport,
+) -> Result<()> {
+    loop {
+        match decode_ctx.receive_frame() {
+            Ok(frame) => {
+                let frame_index = report.decoded_frames;
+                report.record_decoded_frame();
+                if frame_index.is_multiple_of(VISUAL_SAMPLE_INTERVAL) {
+                    if let Some(stats) = frame_visual_stats(&frame) {
+                        report.record_stats(stats);
+                    }
+                }
+            }
+            Err(RsmpegError::DecoderDrainError) => break,
+            Err(err) if is_eagain_error(&err) => break,
+            Err(err) => {
+                bail!("Output visual validation failed: decoder receive_frame failed: {err}")
+            }
+        }
+    }
+    Ok(())
+}
+
+fn format_optional_f64(value: Option<f64>) -> String {
+    value
+        .map(|value| format!("{value:.2}"))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn frame_visual_stats(frame: &rsmpeg::avutil::AVFrame) -> Option<FrameVisualStats> {
+    let width = frame.width.max(0) as usize;
+    let height = frame.height.max(0) as usize;
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    unsafe {
+        let raw = frame.as_ptr();
+        let data = (*raw).data;
+        let linesize = (*raw).linesize;
+        let luma = sample_plane(data[0], linesize[0], width, height)?;
+        let pix_fmt = frame.format as ffi::AVPixelFormat;
+        let (chroma_u_mean, chroma_v_mean) = match pix_fmt {
+            ffi::AV_PIX_FMT_YUV420P | ffi::AV_PIX_FMT_YUVJ420P => {
+                sample_planar_chroma(data, linesize, width.div_ceil(2), height.div_ceil(2))
+            }
+            ffi::AV_PIX_FMT_YUV422P | ffi::AV_PIX_FMT_YUVJ422P => {
+                sample_planar_chroma(data, linesize, width.div_ceil(2), height)
+            }
+            ffi::AV_PIX_FMT_YUV444P | ffi::AV_PIX_FMT_YUVJ444P => {
+                sample_planar_chroma(data, linesize, width, height)
+            }
+            ffi::AV_PIX_FMT_NV12 => sample_interleaved_chroma(
+                data[1],
+                linesize[1],
+                width.div_ceil(2),
+                height.div_ceil(2),
+                true,
+            ),
+            ffi::AV_PIX_FMT_NV21 => sample_interleaved_chroma(
+                data[1],
+                linesize[1],
+                width.div_ceil(2),
+                height.div_ceil(2),
+                false,
+            ),
+            _ => (None, None),
+        };
+
+        Some(FrameVisualStats {
+            luma_mean: luma.mean,
+            luma_stddev: luma.stddev,
+            chroma_u_mean,
+            chroma_v_mean,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PlaneStats {
+    mean: f64,
+    stddev: f64,
+}
+
+unsafe fn sample_planar_chroma(
+    data: [*mut u8; 8],
+    linesize: [i32; 8],
+    width: usize,
+    height: usize,
+) -> (Option<f64>, Option<f64>) {
+    let u = sample_plane(data[1], linesize[1], width, height).map(|stats| stats.mean);
+    let v = sample_plane(data[2], linesize[2], width, height).map(|stats| stats.mean);
+    (u, v)
+}
+
+unsafe fn sample_interleaved_chroma(
+    ptr: *const u8,
+    linesize: i32,
+    width: usize,
+    height: usize,
+    uv_order: bool,
+) -> (Option<f64>, Option<f64>) {
+    if ptr.is_null() || linesize <= 0 || width == 0 || height == 0 {
+        return (None, None);
+    }
+    let step = sample_step(width, height);
+    let mut u_sum = 0f64;
+    let mut v_sum = 0f64;
+    let mut count = 0usize;
+    for y in (0..height).step_by(step) {
+        let row = ptr.add(y * linesize as usize);
+        for x in (0..width).step_by(step) {
+            let pair = row.add(x * 2);
+            let first = *pair as f64;
+            let second = *pair.add(1) as f64;
+            if uv_order {
+                u_sum += first;
+                v_sum += second;
+            } else {
+                v_sum += first;
+                u_sum += second;
+            }
+            count += 1;
+        }
+    }
+    if count == 0 {
+        return (None, None);
+    }
+    (Some(u_sum / count as f64), Some(v_sum / count as f64))
+}
+
+unsafe fn sample_plane(
+    ptr: *const u8,
+    linesize: i32,
+    width: usize,
+    height: usize,
+) -> Option<PlaneStats> {
+    if ptr.is_null() || linesize <= 0 || width == 0 || height == 0 {
+        return None;
+    }
+    let step = sample_step(width, height);
+    let mut sum = 0f64;
+    let mut sum_sq = 0f64;
+    let mut count = 0usize;
+    for y in (0..height).step_by(step) {
+        let row = ptr.add(y * linesize as usize);
+        for x in (0..width).step_by(step) {
+            let value = *row.add(x) as f64;
+            sum += value;
+            sum_sq += value * value;
+            count += 1;
+        }
+    }
+    if count == 0 {
+        return None;
+    }
+    let mean = sum / count as f64;
+    let variance = (sum_sq / count as f64 - mean * mean).max(0.0);
+    Some(PlaneStats {
+        mean,
+        stddev: variance.sqrt(),
+    })
+}
+
+fn sample_step(width: usize, height: usize) -> usize {
+    (((width.saturating_mul(height)) as f64 / 4096.0)
+        .sqrt()
+        .ceil() as usize)
+        .max(1)
+}
+
 fn video_temporal_collapse_error(
     source: VideoTemporalInfo,
     output: VideoTemporalInfo,
@@ -246,6 +622,60 @@ mod tests {
         let output = temporal(Some(1405.45), Some(9.67));
 
         assert!(video_temporal_collapse_error(source, output).is_none());
+    }
+
+    #[test]
+    fn visual_stats_flags_green_screen_like_frames() {
+        let stats = FrameVisualStats {
+            luma_mean: 145.0,
+            luma_stddev: 4.0,
+            chroma_u_mean: Some(54.0),
+            chroma_v_mean: Some(34.0),
+        };
+
+        assert!(stats.suspicious_green_screen());
+    }
+
+    #[test]
+    fn visual_stats_do_not_flag_varied_natural_frames_as_green_screen() {
+        let stats = FrameVisualStats {
+            luma_mean: 110.0,
+            luma_stddev: 70.0,
+            chroma_u_mean: Some(80.0),
+            chroma_v_mean: Some(90.0),
+        };
+
+        assert!(!stats.suspicious_green_screen());
+    }
+
+    #[test]
+    fn visual_report_requires_majority_green_samples_before_failing() {
+        let mut report = VisualInspectionReport::default();
+        let green = FrameVisualStats {
+            luma_mean: 145.0,
+            luma_stddev: 4.0,
+            chroma_u_mean: Some(54.0),
+            chroma_v_mean: Some(34.0),
+        };
+        let normal = FrameVisualStats {
+            luma_mean: 110.0,
+            luma_stddev: 40.0,
+            chroma_u_mean: Some(128.0),
+            chroma_v_mean: Some(128.0),
+        };
+
+        report.record_stats(green);
+        report.record_stats(green);
+        report.record_stats(normal);
+
+        assert!(report.green_failure());
+
+        let mut mostly_normal = VisualInspectionReport::default();
+        mostly_normal.record_stats(green);
+        mostly_normal.record_stats(normal);
+        mostly_normal.record_stats(normal);
+
+        assert!(!mostly_normal.green_failure());
     }
 
     #[test]


### PR DESCRIPTION
**What changed**

DPN now validates converted output by default before it can be promoted. It rejects outputs with missing required streams, unsupported attachment or data streams, or collapsed video timing.

This adds default-on visual validation for corruption that can decode cleanly but still look broken in Plex. The verifier software-decodes sampled frames, calculates per-plane mean values [1], measures luma variation [2], derives green bias [3], flags suspicious green frames [4], flags near-solid nonblack frames [5], and fails only when the sampled green-frame count crosses the configured threshold [6].

Operators can disable all post-conversion validation with `--no-validate-output`, or disable only visual sampling with `--no-visual-validate-output`. `--visual-quality-report` logs visual statistics without changing pass/fail behavior.

The checked amount is configurable with `--visual-scan-frames` and `--visual-sample-interval`. The failure threshold is configurable with `--visual-failure-ratio` [6]. Config-file keys are `visual_scan_frames`, `visual_sample_interval`, and `visual_failure_ratio`; explicit CLI values take precedence.

Fixes #151.

Validation: local fmt, markdownlint, clippy `-D warnings`, focused validation/visual tests, and full `direct_play_nice` binary tests passed. GitHub Markdown rendering was checked for visible body references `[1]` through `[6]`, horizontal rule, and LaTeX math.

---

1. Mean: $`\mu = \frac{1}{n}\sum_{i=1}^{n}x_i`$.

2. Luma variation: $`\sigma = \sqrt{\max(0, \frac{1}{n}\sum_{i=1}^{n}x_i^2 - \mu^2)}`$.

3. Green bias: $`B_g = \max(128 - \mu_U, 0) + \max(128 - \mu_V, 0)`$.

4. Suspicious green frame: $`\mu_Y > 25`$, $`\sigma_Y < 55`$, $`\mu_U < 100`$, $`\mu_V < 115`$, and $`B_g > 45`$.

5. Near-solid nonblack frame: $`25 < \mu_Y < 235`$ and $`\sigma_Y < 2.5`$.

6. Let $`F`$ be scanned decoded frames, default $`120`$; $`I`$ be the sample interval, default $`15`$; $`r`$ be the failure ratio, default $`0.60`$; $`N`$ be inspectable sampled frames; and $`G`$ be suspicious green frames. Threshold: $`T = \max(\lceil rN \rceil, 2)`$. Failure requires $`N \ge 3`$ and $`G \ge T`$.
