### PR TITLE
Add Servarr audit no-candidate cooldown

### DIFF
--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -71,6 +71,7 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-language-audit-lookback-days <DAYS>` recent import window for
   history audit mode
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run
+- `--servarr-language-audit-no-candidate-cooldown-days <D>` skip release-searching items with a recent no-candidate audit result for `D` days; `0` disables this
 - `--servarr-language-audit-episode-ids <IDS>` comma-separated Sonarr episode
   IDs to audit instead of the full scope
 - `--servarr-language-check` enable pre-conversion language checks for Arr

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -71,7 +71,8 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-language-audit-lookback-days <DAYS>` recent import window for
   history audit mode
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run
-- `--servarr-language-audit-no-candidate-cooldown-days <D>` skip release-searching items with a recent no-candidate audit result for `D` days; `0` disables this
+- `--servarr-language-audit-no-candidate-cooldown-days <D>` skip items
+  with a recent no-candidate audit result for `D` days; `0` disables this
 - `--servarr-language-audit-episode-ids <IDS>` comma-separated Sonarr episode
   IDs to audit instead of the full scope
 - `--servarr-language-check` enable pre-conversion language checks for Arr

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -200,12 +200,18 @@ For focused Sonarr batches, pass `--servarr-language-audit-episode-ids` with a
 comma-separated episode ID list.
 
 DPN also checks completed pending imports that Sonarr/Radarr refused for quality
-hierarchy reasons. Sonarr auto-grabs are limited to releases that map back to the
-single requested episode; multi-episode and season-pack results are skipped even
-when their titles contain strong language hints. Keep dry-run enabled while
-reviewing reports; remove `--servarr-language-dry-run` only when you want DPN to
-grab selected language-upgrade candidates, blocklist the old history item, and
-force-import eligible pending replacements.
+hierarchy reasons. When deciding whether to force-import a pending language
+upgrade, DPN inspects the existing media file's actual stream metadata instead of
+trusting Arr's language label. This lets a lower-quality pending file replace a
+higher-quality current file only when the current file is missing a required
+language and the pending file satisfies the language policy.
+
+Sonarr auto-grabs are limited to releases that map back to the single requested
+episode; multi-episode and season-pack results are skipped even when their titles
+contain strong language hints. Keep dry-run enabled while reviewing reports;
+remove `--servarr-language-dry-run` only when you want DPN to grab selected
+language-upgrade candidates, blocklist the old history item, and force-import
+eligible pending replacements.
 
 This feature assumes DPN is the authority for language upgrades. To avoid Arr
 and DPN fighting each other, keep ordinary Arr quality-only upgrades conservative
@@ -268,7 +274,13 @@ observable batches. A safe operator workflow is:
    candidates may remain queued/downloading for a while, and failed alternates in
    history do not necessarily mean the current queued candidate failed.
 
-6. **Verify and repeat.** Re-run the same command with
+6. **Prioritize recent episodes when needed.** DPN can target a caller-supplied
+   list of Sonarr episode IDs. A wrapper can query Sonarr for the latest aired
+   episodes with files, sort by `airDateUtc` descending, take the newest 100, and
+   pass them with `--servarr-language-audit-episode-ids`. This creates a
+   recently-aired priority lane before the broader inventory backlog pass.
+
+7. **Verify and repeat.** Re-run the same command with
    `--servarr-language-dry-run`. Completed items should no longer be searched;
    remaining missing items should either show a queued candidate, no candidate,
    or a rejection reason to fix before another apply batch.

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -84,6 +84,8 @@ servarr_language_audit = true
 servarr_language_audit_scope = "history"
 servarr_language_audit_lookback_days = 30
 servarr_language_audit_max_searches = 20
+# Optional: prevent persistent no-candidate items from consuming every audit run.
+servarr_language_audit_no_candidate_cooldown_days = 14
 # Optional: limit a Sonarr audit to specific episode IDs.
 # servarr_language_audit_episode_ids = "123,456"
 required_audio_languages = "eng"
@@ -182,6 +184,18 @@ up to `--servarr-language-audit-max-searches`. Use
 library inventory instead of only recent import history. Inventory scope walks
 series episode files, checks current media metadata, then uses each missing
 item's latest import history entry before any apply-mode grab/blocklist action.
+
+If early inventory items repeatedly return no approved replacement, set
+`--servarr-language-audit-no-candidate-cooldown-days` (or
+`servarr_language_audit_no_candidate_cooldown_days`) so those no-candidate items
+are not release-searched again until the cooldown expires. DPN stores this
+best-effort state in
+`$XDG_CACHE_HOME/direct-play-nice/servarr-language-no-candidate-cache.json` or
+`~/.cache/direct-play-nice/servarr-language-no-candidate-cache.json`; override it
+with `DIRECT_PLAY_NICE_LANGUAGE_NO_CANDIDATE_CACHE`. This lets later inventory
+items get searched on subsequent capped audit runs instead of reprocessing the
+same no-candidate edge every day.
+
 For focused Sonarr batches, pass `--servarr-language-audit-episode-ids` with a
 comma-separated episode ID list.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ pub struct Config {
     pub servarr_language_audit_scope: Option<ServarrLanguageAuditScope>,
     pub servarr_language_audit_lookback_days: Option<u32>,
     pub servarr_language_audit_max_searches: Option<usize>,
+    pub servarr_language_audit_no_candidate_cooldown_days: Option<u32>,
     pub servarr_language_audit_episode_ids: Option<String>,
     pub servarr_language_check: Option<bool>,
     pub required_audio_languages: Option<String>,
@@ -269,6 +270,7 @@ mod tests {
             servarr_language_audit_scope = "inventory"
             servarr_language_audit_lookback_days = 30
             servarr_language_audit_max_searches = 20
+            servarr_language_audit_no_candidate_cooldown_days = 14
             servarr_language_audit_episode_ids = "1,2,3"
             servarr_language_check = true
             required_audio_languages = "eng,jpn"
@@ -291,6 +293,10 @@ mod tests {
         );
         assert_eq!(cfg.servarr_language_audit_lookback_days, Some(30));
         assert_eq!(cfg.servarr_language_audit_max_searches, Some(20));
+        assert_eq!(
+            cfg.servarr_language_audit_no_candidate_cooldown_days,
+            Some(14)
+        );
         assert_eq!(
             cfg.servarr_language_audit_episode_ids.as_deref(),
             Some("1,2,3")

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -163,6 +163,12 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_audit_no_candidate_cooldown_days") {
+        if let Some(days) = cfg.servarr_language_audit_no_candidate_cooldown_days {
+            args.servarr_language_audit_no_candidate_cooldown_days = days;
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_audit_episode_ids") {
         if let Some(ids) = cfg.servarr_language_audit_episode_ids.as_ref() {
             args.servarr_language_audit_episode_ids = Some(ids.clone());
@@ -365,6 +371,7 @@ mod tests {
             servarr_language_audit_scope: Some(crate::ServarrLanguageAuditScope::Inventory),
             servarr_language_audit_lookback_days: Some(30),
             servarr_language_audit_max_searches: Some(20),
+            servarr_language_audit_no_candidate_cooldown_days: Some(14),
             servarr_language_audit_episode_ids: Some("77,88".to_string()),
             servarr_language_check: Some(true),
             required_audio_languages: Some("eng,jpn".to_string()),
@@ -387,6 +394,7 @@ mod tests {
         );
         assert_eq!(args.servarr_language_audit_lookback_days, 30);
         assert_eq!(args.servarr_language_audit_max_searches, 20);
+        assert_eq!(args.servarr_language_audit_no_candidate_cooldown_days, 14);
         assert_eq!(
             args.servarr_language_audit_episode_ids.as_deref(),
             Some("77,88")

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -236,6 +236,14 @@ pub(crate) struct Args {
     )]
     pub(crate) servarr_language_audit_max_searches: usize,
 
+    /// Days to skip release-searching an item after a no-candidate audit result. Zero disables cooldown.
+    #[arg(
+        long = "servarr-language-audit-no-candidate-cooldown-days",
+        default_value_t = 0,
+        id = "servarr_language_audit_no_candidate_cooldown_days"
+    )]
+    pub(crate) servarr_language_audit_no_candidate_cooldown_days: u32,
+
     /// Optional comma-separated Sonarr episode IDs to audit instead of the full scope.
     #[arg(
         long = "servarr-language-audit-episode-ids",

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -45,6 +45,7 @@ pub struct AuditOptions {
     pub scope: ServarrLanguageAuditScope,
     pub lookback_days: u32,
     pub max_searches: usize,
+    pub no_candidate_cooldown_days: u32,
     pub episode_ids: Vec<i64>,
     pub untagged_retag: UntaggedRetagOptions,
 }
@@ -55,6 +56,7 @@ impl Default for AuditOptions {
             scope: ServarrLanguageAuditScope::History,
             lookback_days: 30,
             max_searches: 20,
+            no_candidate_cooldown_days: 0,
             episode_ids: Vec::new(),
             untagged_retag: UntaggedRetagOptions::default(),
         }
@@ -69,6 +71,7 @@ pub struct AuditSummary {
     pub grabbed: usize,
     pub dry_run: usize,
     pub no_candidate: usize,
+    pub skipped_no_candidate_cooldown: usize,
     pub errors: usize,
 }
 
@@ -80,6 +83,7 @@ impl AuditSummary {
         self.grabbed += other.grabbed;
         self.dry_run += other.dry_run;
         self.no_candidate += other.no_candidate;
+        self.skipped_no_candidate_cooldown += other.skipped_no_candidate_cooldown;
         self.errors += other.errors;
     }
 }
@@ -177,6 +181,7 @@ fn run_sonarr_history_language_audit(
             requirements,
             redownload_options,
             audit_options.max_searches,
+            audit_options.no_candidate_cooldown_days,
             &audit_options.untagged_retag,
             active_queue_episode_ids,
             &mut searched,
@@ -214,6 +219,7 @@ fn run_sonarr_inventory_language_audit(
             requirements,
             redownload_options,
             audit_options.max_searches,
+            audit_options.no_candidate_cooldown_days,
             &audit_options.untagged_retag,
             active_queue_episode_ids,
             &mut searched,
@@ -233,6 +239,7 @@ fn process_sonarr_language_audit_item(
     requirements: &LanguageRequirements,
     redownload_options: RedownloadOptions,
     max_searches: usize,
+    no_candidate_cooldown_days: u32,
     untagged_retag: &UntaggedRetagOptions,
     active_queue_episode_ids: &BTreeSet<i64>,
     searched: &mut usize,
@@ -267,6 +274,29 @@ fn process_sonarr_language_audit_item(
         );
         return;
     }
+    if no_candidate_cooldown_days > 0 {
+        match cache::no_candidate_cooldown_remaining_days(
+            client.kind,
+            "episode",
+            episode_id,
+            requirements,
+            no_candidate_cooldown_days,
+        ) {
+            Ok(Some(days_remaining)) => {
+                summary.skipped_no_candidate_cooldown += 1;
+                info!(
+                    "Sonarr language audit skipping release search for episode {} because a no-candidate result is cooling down for {} more day(s).",
+                    episode_id, days_remaining
+                );
+                return;
+            }
+            Ok(None) => {}
+            Err(err) => warn!(
+                "Sonarr language audit could not read no-candidate cooldown cache for episode {}: {}",
+                episode_id, err
+            ),
+        }
+    }
     if *searched >= max_searches {
         return;
     }
@@ -294,6 +324,7 @@ fn process_sonarr_language_audit_item(
                 0,
                 requirements,
                 redownload_options,
+                no_candidate_cooldown_days,
                 summary,
             );
         } else {
@@ -311,6 +342,7 @@ fn process_sonarr_language_audit_item(
         history_id,
         requirements,
         redownload_options,
+        no_candidate_cooldown_days,
         summary,
     );
 }
@@ -360,6 +392,7 @@ pub fn run_radarr_language_audit(
             history_id,
             requirements,
             redownload_options,
+            audit_options.no_candidate_cooldown_days,
             &mut summary,
         );
     }
@@ -1130,6 +1163,7 @@ impl ApiClient {
         history_id: i64,
         requirements: &LanguageRequirements,
         options: RedownloadOptions,
+        no_candidate_cooldown_days: u32,
         summary: &mut AuditSummary,
     ) {
         let label = self.kind.label();
@@ -1157,6 +1191,23 @@ impl ApiClient {
             }
             Ok(RedownloadOutcome::NoVerifiedRelease { reason }) => {
                 summary.no_candidate += 1;
+                if no_candidate_cooldown_days > 0 {
+                    if let Err(err) = cache::record_no_candidate(
+                        self.kind,
+                        target.noun(),
+                        target_id,
+                        requirements,
+                        &reason,
+                    ) {
+                        warn!(
+                            "{} language audit failed to update no-candidate cooldown cache for {} {}: {}",
+                            label,
+                            target.noun(),
+                            target_id,
+                            err
+                        );
+                    }
+                }
                 info!(
                     "{} language audit found no replacement for {} {}: {}",
                     label,
@@ -1426,7 +1477,7 @@ fn record_language_audit_assessment(
 
 fn log_audit_summary(label: &str, summary: &AuditSummary) {
     info!(
-        "{} language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, errors={}",
+        "{} language audit complete: checked={}, missing={}, searched={}, dry_run={}, grabbed={}, no_candidate={}, skipped_no_candidate_cooldown={}, errors={}",
         label,
         summary.checked,
         summary.missing,
@@ -1434,6 +1485,7 @@ fn log_audit_summary(label: &str, summary: &AuditSummary) {
         summary.dry_run,
         summary.grabbed,
         summary.no_candidate,
+        summary.skipped_no_candidate_cooldown,
         summary.errors
     );
 }
@@ -2248,6 +2300,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::Inventory,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2354,6 +2407,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::Inventory,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2446,6 +2500,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::Inventory,
                 lookback_days: 30,
                 max_searches: 1,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2518,6 +2573,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::Inventory,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2613,6 +2669,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2687,6 +2744,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::Inventory,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2750,6 +2808,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::Inventory,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2847,6 +2906,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2937,6 +2997,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3012,6 +3073,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3084,6 +3146,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3171,6 +3234,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3246,6 +3310,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3299,6 +3364,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3349,6 +3415,7 @@ mod tests {
                 scope: ServarrLanguageAuditScope::History,
                 lookback_days: 30,
                 max_searches: 10,
+                no_candidate_cooldown_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use log::{info, warn};
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use ureq::{Agent, AgentBuilder};
 
@@ -877,7 +877,7 @@ impl ApiClient {
                     continue;
                 }
             };
-            let current_report = language_report_from_episode_file(&current_file, requirements);
+            let current_report = language_report_from_media_file(&current_file, requirements);
             if current_report.satisfied() {
                 continue;
             }
@@ -1398,6 +1398,31 @@ fn language_report_from_episode_file(
         .map(parse_language_tokens)
         .unwrap_or_default();
     report_from_present(audio, subtitles, requirements)
+}
+
+fn language_report_from_media_file(
+    media_file: &Value,
+    requirements: &LanguageRequirements,
+) -> LanguageCheckReport {
+    let sonarr_report = language_report_from_episode_file(media_file, requirements);
+    let Some(path) = media_file.get("path").and_then(Value::as_str) else {
+        return sonarr_report;
+    };
+    let path = Path::new(path);
+    if !path.exists() {
+        return sonarr_report;
+    }
+    match super::language::check_file(path, requirements) {
+        Ok(report) => report,
+        Err(err) => {
+            warn!(
+                "Could not inspect media file '{}' for actual stream languages; falling back to Arr metadata: {}",
+                path.display(),
+                err
+            );
+            sonarr_report
+        }
+    }
 }
 
 fn maybe_retag_audit_file(

--- a/src/servarr/cache.rs
+++ b/src/servarr/cache.rs
@@ -70,7 +70,7 @@ pub fn no_candidate_cooldown_remaining_days(
                 None
             } else {
                 let remaining_secs = cooldown_secs - elapsed;
-                Some(((remaining_secs + 86_399) / 86_400) as u32)
+                Some(remaining_secs.div_ceil(86_400) as u32)
             }
         }))
 }

--- a/src/servarr/cache.rs
+++ b/src/servarr/cache.rs
@@ -21,6 +21,17 @@ struct CacheRecord {
     report: LanguageCheckReport,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NoCandidateRecord {
+    key: String,
+    kind: String,
+    target_noun: String,
+    target_id: i64,
+    checked_at_unix: u64,
+    requirements: LanguageRequirements,
+    reason: String,
+}
+
 pub fn record_assessment(
     kind: IntegrationKind,
     path: &Path,
@@ -31,6 +42,86 @@ pub fn record_assessment(
         return Ok(());
     };
     record_assessment_at_path(&cache_path, kind, path, requirements, report)
+}
+
+pub fn no_candidate_cooldown_remaining_days(
+    kind: IntegrationKind,
+    target_noun: &str,
+    target_id: i64,
+    requirements: &LanguageRequirements,
+    cooldown_days: u32,
+) -> Result<Option<u32>> {
+    if cooldown_days == 0 {
+        return Ok(None);
+    }
+    let Some(cache_path) = resolve_no_candidate_cache_path() else {
+        return Ok(None);
+    };
+    let records = read_no_candidate_records(&cache_path)?;
+    let key = no_candidate_key(kind, target_noun, target_id);
+    let now = now_unix_secs();
+    let cooldown_secs = u64::from(cooldown_days) * 86_400;
+    Ok(records
+        .into_iter()
+        .find(|record| record.key == key && record.requirements == *requirements)
+        .and_then(|record| {
+            let elapsed = now.saturating_sub(record.checked_at_unix);
+            if elapsed >= cooldown_secs {
+                None
+            } else {
+                let remaining_secs = cooldown_secs - elapsed;
+                Some(((remaining_secs + 86_399) / 86_400) as u32)
+            }
+        }))
+}
+
+pub fn record_no_candidate(
+    kind: IntegrationKind,
+    target_noun: &str,
+    target_id: i64,
+    requirements: &LanguageRequirements,
+    reason: &str,
+) -> Result<()> {
+    let Some(cache_path) = resolve_no_candidate_cache_path() else {
+        return Ok(());
+    };
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "creating language no-candidate cache directory '{}'",
+                parent.display()
+            )
+        })?;
+    }
+
+    let key = no_candidate_key(kind, target_noun, target_id);
+    let mut records = read_no_candidate_records(&cache_path)?;
+    records.retain(|record| record.key != key);
+    records.push(NoCandidateRecord {
+        key,
+        kind: format!("{:?}", kind),
+        target_noun: target_noun.to_string(),
+        target_id,
+        checked_at_unix: now_unix_secs(),
+        requirements: requirements.clone(),
+        reason: reason.to_string(),
+    });
+    records.sort_by(|a, b| a.key.cmp(&b.key));
+    let tmp_path = cache_path.with_extension("json.tmp");
+    fs::write(&tmp_path, serde_json::to_vec_pretty(&records)?).with_context(|| {
+        format!(
+            "writing language no-candidate cache '{}'",
+            tmp_path.display()
+        )
+    })?;
+    fs::rename(&tmp_path, &cache_path).with_context(|| {
+        format!(
+            "renaming language no-candidate cache '{}' to '{}'",
+            tmp_path.display(),
+            cache_path.display()
+        )
+    })?;
+    Ok(())
 }
 
 fn record_assessment_at_path(
@@ -51,10 +142,7 @@ fn record_assessment_at_path(
     records.push(CacheRecord {
         path: path_string,
         kind: format!("{:?}", kind),
-        checked_at_unix: SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs(),
+        checked_at_unix: now_unix_secs(),
         requirements: requirements.clone(),
         report: report.clone(),
     });
@@ -90,6 +178,43 @@ fn read_records(path: &Path) -> Result<Vec<CacheRecord>> {
             Err(err).with_context(|| format!("reading language cache '{}'", path.display()))
         }
     }
+}
+
+fn read_no_candidate_records(path: &Path) -> Result<Vec<NoCandidateRecord>> {
+    match fs::read_to_string(path) {
+        Ok(contents) => match serde_json::from_str(&contents) {
+            Ok(records) => Ok(records),
+            Err(err) => {
+                warn!(
+                    "Ignoring corrupt language no-candidate cache '{}': {}",
+                    path.display(),
+                    err
+                );
+                Ok(Vec::new())
+            }
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(err) => Err(err)
+            .with_context(|| format!("reading language no-candidate cache '{}'", path.display())),
+    }
+}
+
+fn resolve_no_candidate_cache_path() -> Option<PathBuf> {
+    if let Some(path) = env::var_os("DIRECT_PLAY_NICE_LANGUAGE_NO_CANDIDATE_CACHE") {
+        return Some(PathBuf::from(path));
+    }
+    resolve_cache_path().map(|path| path.with_file_name("servarr-language-no-candidate-cache.json"))
+}
+
+fn no_candidate_key(kind: IntegrationKind, target_noun: &str, target_id: i64) -> String {
+    format!("{:?}:{}:{}", kind, target_noun, target_id)
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 fn resolve_cache_path() -> Option<PathBuf> {
@@ -177,5 +302,56 @@ mod tests {
         assert!(contents.contains("/media/show.mkv"));
         assert!(contents.contains("jpn"));
         assert!(contents.contains("eng"));
+    }
+
+    #[test]
+    fn records_and_reads_no_candidate_cooldown() {
+        let tmp = TempDir::new().unwrap();
+        let cache_path = tmp.path().join("no-candidates.json");
+        std::env::set_var("DIRECT_PLAY_NICE_LANGUAGE_NO_CANDIDATE_CACHE", &cache_path);
+
+        let requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string()],
+            subtitles: Vec::new(),
+        };
+
+        record_no_candidate(
+            IntegrationKind::Sonarr,
+            "episode",
+            42,
+            &requirements,
+            "no approved release",
+        )
+        .unwrap();
+
+        let remaining = no_candidate_cooldown_remaining_days(
+            IntegrationKind::Sonarr,
+            "episode",
+            42,
+            &requirements,
+            14,
+        )
+        .unwrap();
+        assert_eq!(remaining, Some(14));
+
+        let different_requirements = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string(), "jpn".to_string()],
+            subtitles: Vec::new(),
+        };
+        assert_eq!(
+            no_candidate_cooldown_remaining_days(
+                IntegrationKind::Sonarr,
+                "episode",
+                42,
+                &different_requirements,
+                14,
+            )
+            .unwrap(),
+            None
+        );
+
+        std::env::remove_var("DIRECT_PLAY_NICE_LANGUAGE_NO_CANDIDATE_CACHE");
     }
 }

--- a/src/servarr/language.rs
+++ b/src/servarr/language.rs
@@ -16,7 +16,7 @@ use std::ffi::CString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LanguageRequirements {
     pub enabled: bool,
     pub audio: Vec<String>,

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -243,6 +243,7 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
             scope: args.servarr_language_audit_scope,
             lookback_days: args.servarr_language_audit_lookback_days,
             max_searches: args.servarr_language_audit_max_searches,
+            no_candidate_cooldown_days: args.servarr_language_audit_no_candidate_cooldown_days,
             episode_ids: parse_optional_i64_list(
                 args.servarr_language_audit_episode_ids.as_deref(),
             )?,


### PR DESCRIPTION
## Problem

Fixes #155: Servarr inventory audits can spend the whole capped search budget on the same no-candidate episodes, which leaves later library items unsearched. Sonarr can also block a valid language upgrade as a quality downgrade when the current file is Bluray and the pending English-audio file is WEBDL.

## What's changed

This adds `servarr_language_audit_no_candidate_cooldown_days` and `--servarr-language-audit-no-candidate-cooldown-days`. DPN stores no-candidate results in a cache and skips those items while the cooldown is active, so they do not consume the per-run search cap.

DPN also checks actual media stream metadata before force-importing pending language upgrades. That lets a lower-quality pending file replace a higher-quality current file only when the current file is missing the required language and the pending file satisfies the language policy.

The docs now cover the cooldown cache, pending force-import behavior, and the latest-episode targeted audit pattern.

## Workflow

```mermaid
flowchart TD
    A["Start language audit"] --> B{"Scope"}
    B -->|"history"| C["Recent import history"]
    B -->|"inventory"| D["Current Sonarr files"]
    C --> E["Check actual stream languages"]
    D --> E
    E --> F{"Required language present"}
    F -->|"yes"| G["Skip"]
    F -->|"no"| H{"Active queue item"}
    H -->|"yes"| I["Skip duplicate grab"]
    H -->|"no"| J{"No-candidate cooldown"}
    J -->|"active"| K["Skip without using search cap"]
    J -->|"inactive"| L["Search Arr releases"]
    L --> M{"Approved candidate"}
    M -->|"no"| N["Record cooldown"]
    M -->|"yes"| O["Grab replacement"]
    O --> P{"Import blocked by quality"}
    P -->|"yes"| Q["Verify current and pending streams"]
    Q --> R{"Pending fixes missing language"}
    R -->|"yes"| S["Force import"]
    P -->|"no"| T["Normal import"]
```

Checked with `cargo fmt`, `git diff --check`, GitHub Actions, and live plexserver audit runs that skipped cooled-down items and force-imported real language upgrades.
