### PR TITLE
Prepare 1.1.0-beta.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0-beta.4] - 2026-06-27
+
+### Servarr Language Audit
+
+- Added a no-candidate cooldown for Servarr language audits so capped inventory
+  runs skip recent dead-end searches and continue deeper into the library.
+- Added audit summary reporting for items skipped by the no-candidate cooldown.
+- Fixed Sonarr pending language-upgrade force imports to inspect the current
+  media file's actual stream languages instead of trusting Sonarr's stored
+  language label.
+- Documented a latest-aired episode priority lane using targeted Sonarr episode
+  IDs before broad inventory backlog cleanup.
+
+### Documentation
+
+- Documented the no-candidate cache path and override environment variable.
+- Documented the quality-downgrade force-import safety check for pending
+  language upgrades.
+
 ## [1.1.0-beta.3] - 2026-06-08
 
 ### 🛠️ CUDA Resize Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "1.1.0-beta.3"
+version = "1.1.0-beta.4"
 edition = "2021"
 
 


### PR DESCRIPTION
## Problem

Fixes #156: The Servarr language audit fixes merged after `v1.1.0-beta.3` are running on `plexserver`, but they are not available from a tagged release yet.

## What's changed

This bumps the crate to `1.1.0-beta.4` and adds release notes for the Servarr language audit work.

The release notes cover the no-candidate cooldown, the new cooldown summary count, safer Sonarr pending force-import checks that inspect actual media streams, and the latest-aired episode audit pattern.

Checked with `cargo fmt` and `git diff --check`.
