### PR TITLE
Add Sonarr latest-missing language audit scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ servarr_untagged_audio_language = "eng"
 
 To catch delayed dubs/subs that arrive after the first import, run the same
 binary periodically with `--servarr-language-audit`. Use
-`--servarr-language-audit-scope inventory` for a Sonarr current-library sweep.
+`--servarr-language-audit-scope latest-missing` for a Sonarr pass that spends the
+search budget on the newest aired non-compliant episodes first, or
+`--servarr-language-audit-scope inventory` for a full current-library sweep.
 Before applying broad language replacements, follow the
 [Safe language upgrade runbook](https://ns-mkusper.github.io/direct-play-nice/servarr.html#safe-language-upgrade-runbook)
 in the Sonarr/Radarr manual.

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -66,8 +66,8 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-output-suffix <servarr_output_suffix>`
 - `--servarr-language-audit` run a periodic Sonarr/Radarr audit for
   delayed language upgrades
-- `--servarr-language-audit-scope <SCOPE>` choose `history` or Sonarr-only
-  `inventory` audit source
+- `--servarr-language-audit-scope <SCOPE>` choose `history`, Sonarr-only
+  `inventory`, or Sonarr-only `latest-missing` audit source
 - `--servarr-language-audit-lookback-days <DAYS>` recent import window for
   history audit mode
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -184,6 +184,10 @@ up to `--servarr-language-audit-max-searches`. Use
 library inventory instead of only recent import history. Inventory scope walks
 series episode files, checks current media metadata, then uses each missing
 item's latest import history entry before any apply-mode grab/blocklist action.
+Use `--servarr-language-audit-scope latest-missing` with Sonarr to inspect
+inventory, keep only currently non-compliant episode files, sort those by newest
+air date first, and spend the search budget on recent delayed dubs/subs before
+older backlog.
 
 If early inventory items repeatedly return no approved replacement, set
 `--servarr-language-audit-no-candidate-cooldown-days` (or
@@ -236,7 +240,20 @@ observable batches. A safe operator workflow is:
      --servarr-language-dry-run
    ```
 
-2. **Use inventory dry-run for backlog discovery.** This is Sonarr-only and can
+2. **Use `latest-missing` dry-run for delayed dub/sub follow-up.** This is
+   Sonarr-only and prioritizes newest aired non-compliant episode files before
+   older backlog:
+
+   ```bash
+   /path/to/direct_play_nice \
+     --config-file /path/to/direct-play-nice-sonarr.toml \
+     --servarr-language-audit \
+     --servarr-language-audit-scope latest-missing \
+     --servarr-language-audit-max-searches 25 \
+     --servarr-language-dry-run
+   ```
+
+3. **Use inventory dry-run for backlog discovery.** This is Sonarr-only and can
    be slow on large libraries, so keep the search cap low while tuning:
 
    ```bash
@@ -248,14 +265,14 @@ observable batches. A safe operator workflow is:
      --servarr-language-dry-run
    ```
 
-3. **Review candidate evidence before apply mode.** Prefer candidates with
+4. **Review candidate evidence before apply mode.** Prefer candidates with
    explicit Arr language metadata or strong custom-format/title evidence such as
    `Anime-multi-audio`, `anime-multi-sub`, `Dual-Audio`, `Multi-Audio`, or
    `Multi-Subs`. Treat unrelated rejections such as blocked indexers, unknown
    series, or seed/availability failures as blockers. Do not add subtitle
    requirements unless missing subtitles should trigger redownloads.
 
-4. **Apply only a focused batch.** Use Sonarr episode IDs from the dry-run logs
+5. **Apply only a focused batch.** Use Sonarr episode IDs from the dry-run logs
    to constrain the destructive run. Keep `--servarr-language-audit-max-searches`
    at or below the number of intended items:
 
@@ -268,19 +285,18 @@ observable batches. A safe operator workflow is:
      --servarr-language-audit-max-searches 3
    ```
 
-5. **Watch Arr's queue and history.** A successful Sonarr language replacement
+6. **Watch Arr's queue and history.** A successful Sonarr language replacement
    usually goes `grabbed` → `downloadFolderImported`; the imported file should
    then show the required audio/subtitle languages in Arr media info. Some
    candidates may remain queued/downloading for a while, and failed alternates in
    history do not necessarily mean the current queued candidate failed.
 
-6. **Prioritize recent episodes when needed.** DPN can target a caller-supplied
-   list of Sonarr episode IDs. A wrapper can query Sonarr for the latest aired
-   episodes with files, sort by `airDateUtc` descending, take the newest 100, and
-   pass them with `--servarr-language-audit-episode-ids`. This creates a
-   recently-aired priority lane before the broader inventory backlog pass.
+7. **Prioritize recent episodes when needed.** Prefer `latest-missing` for a
+   built-in newest-missing priority lane. DPN can also target a caller-supplied
+   list of Sonarr episode IDs with `--servarr-language-audit-episode-ids` for
+   fully custom batches.
 
-7. **Verify and repeat.** Re-run the same command with
+8. **Verify and repeat.** Re-run the same command with
    `--servarr-language-dry-run`. Completed items should no longer be searched;
    remaining missing items should either show a queued candidate, no candidate,
    or a rejection reason to fix before another apply batch.

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,7 +267,7 @@ mod tests {
             tmp,
             r#"
             servarr_language_audit = true
-            servarr_language_audit_scope = "inventory"
+            servarr_language_audit_scope = "latest-missing"
             servarr_language_audit_lookback_days = 30
             servarr_language_audit_max_searches = 20
             servarr_language_audit_no_candidate_cooldown_days = 14
@@ -289,7 +289,7 @@ mod tests {
         assert_eq!(cfg.servarr_language_audit, Some(true));
         assert_eq!(
             cfg.servarr_language_audit_scope,
-            Some(ServarrLanguageAuditScope::Inventory)
+            Some(ServarrLanguageAuditScope::LatestMissing)
         );
         assert_eq!(cfg.servarr_language_audit_lookback_days, Some(30));
         assert_eq!(cfg.servarr_language_audit_max_searches, Some(20));

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -368,7 +368,7 @@ mod tests {
         let (mut args, matches) = parse_args(&["direct_play_nice"]);
         let cfg = config::Config {
             servarr_language_audit: Some(true),
-            servarr_language_audit_scope: Some(crate::ServarrLanguageAuditScope::Inventory),
+            servarr_language_audit_scope: Some(crate::ServarrLanguageAuditScope::LatestMissing),
             servarr_language_audit_lookback_days: Some(30),
             servarr_language_audit_max_searches: Some(20),
             servarr_language_audit_no_candidate_cooldown_days: Some(14),
@@ -390,7 +390,7 @@ mod tests {
         assert!(args.servarr_language_audit);
         assert_eq!(
             args.servarr_language_audit_scope,
-            crate::ServarrLanguageAuditScope::Inventory
+            crate::ServarrLanguageAuditScope::LatestMissing
         );
         assert_eq!(args.servarr_language_audit_lookback_days, 30);
         assert_eq!(args.servarr_language_audit_max_searches, 20);

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -211,7 +211,7 @@ pub(crate) struct Args {
     )]
     pub(crate) servarr_language_audit: bool,
 
-    /// Servarr audit source: recent import history or current library inventory.
+    /// Servarr audit source: recent import history, current library inventory, or newest missing-language Sonarr inventory items.
     #[arg(
         long = "servarr-language-audit-scope",
         value_enum,

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -75,6 +75,13 @@ pub struct AuditSummary {
     pub errors: usize,
 }
 
+#[derive(Debug, Clone)]
+struct SonarrInventoryItem {
+    episode_id: i64,
+    episode_file: Value,
+    air_day: Option<i64>,
+}
+
 impl AuditSummary {
     fn merge(&mut self, other: Self) {
         self.checked += other.checked;
@@ -135,6 +142,13 @@ pub fn run_sonarr_language_audit(
             &active_queue_episode_ids,
         )?,
         ServarrLanguageAuditScope::Inventory => run_sonarr_inventory_language_audit(
+            &client,
+            requirements,
+            redownload_options,
+            audit_options,
+            &active_queue_episode_ids,
+        )?,
+        ServarrLanguageAuditScope::LatestMissing => run_sonarr_latest_missing_language_audit(
             &client,
             requirements,
             redownload_options,
@@ -230,6 +244,71 @@ fn run_sonarr_inventory_language_audit(
     Ok(summary)
 }
 
+fn run_sonarr_latest_missing_language_audit(
+    client: &ApiClient,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    audit_options: AuditOptions,
+    active_queue_episode_ids: &BTreeSet<i64>,
+) -> Result<AuditSummary> {
+    if !audit_options.episode_ids.is_empty() {
+        return run_sonarr_inventory_language_audit(
+            client,
+            requirements,
+            redownload_options,
+            audit_options,
+            active_queue_episode_ids,
+        );
+    }
+
+    let mut items = client.sonarr_inventory_episode_file_items()?;
+    let mut summary = AuditSummary::default();
+    let mut missing_items = Vec::new();
+
+    for item in items.drain(..) {
+        summary.checked += 1;
+        let report = assess_sonarr_language_audit_item(
+            client,
+            &item.episode_file,
+            requirements,
+            &audit_options.untagged_retag,
+        );
+        if report.satisfied() {
+            continue;
+        }
+        summary.missing += 1;
+        missing_items.push(item);
+    }
+
+    missing_items.sort_by(|left, right| {
+        right
+            .air_day
+            .cmp(&left.air_day)
+            .then_with(|| right.episode_id.cmp(&left.episode_id))
+    });
+
+    let mut searched = 0usize;
+    for item in missing_items {
+        if searched >= audit_options.max_searches {
+            break;
+        }
+        process_sonarr_missing_language_audit_item(
+            client,
+            item.episode_id,
+            None,
+            requirements,
+            redownload_options,
+            audit_options.max_searches,
+            audit_options.no_candidate_cooldown_days,
+            active_queue_episode_ids,
+            &mut searched,
+            &mut summary,
+        );
+    }
+
+    Ok(summary)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn process_sonarr_language_audit_item(
     client: &ApiClient,
@@ -246,11 +325,37 @@ fn process_sonarr_language_audit_item(
     summary: &mut AuditSummary,
 ) {
     summary.checked += 1;
-    let mut report = language_report_from_episode_file(&episode_file, requirements);
+    let report =
+        assess_sonarr_language_audit_item(client, &episode_file, requirements, untagged_retag);
+    if report.satisfied() {
+        return;
+    }
+    summary.missing += 1;
+    process_sonarr_missing_language_audit_item(
+        client,
+        episode_id,
+        history_id,
+        requirements,
+        redownload_options,
+        max_searches,
+        no_candidate_cooldown_days,
+        active_queue_episode_ids,
+        searched,
+        summary,
+    );
+}
+
+fn assess_sonarr_language_audit_item(
+    client: &ApiClient,
+    episode_file: &Value,
+    requirements: &LanguageRequirements,
+    untagged_retag: &UntaggedRetagOptions,
+) -> LanguageCheckReport {
+    let mut report = language_report_from_episode_file(episode_file, requirements);
     if !report.satisfied() && client.kind == IntegrationKind::Sonarr && untagged_retag.enabled() {
         report = maybe_retag_audit_file(
             IntegrationKind::Sonarr,
-            &episode_file,
+            episode_file,
             requirements,
             untagged_retag,
             report,
@@ -259,14 +364,26 @@ fn process_sonarr_language_audit_item(
     record_language_audit_assessment(
         IntegrationKind::Sonarr,
         "sonarr:episodefile",
-        &episode_file,
+        episode_file,
         requirements,
         &report,
     );
-    if report.satisfied() {
-        return;
-    }
-    summary.missing += 1;
+    report
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_sonarr_missing_language_audit_item(
+    client: &ApiClient,
+    episode_id: i64,
+    history_id: Option<i64>,
+    requirements: &LanguageRequirements,
+    redownload_options: RedownloadOptions,
+    max_searches: usize,
+    no_candidate_cooldown_days: u32,
+    active_queue_episode_ids: &BTreeSet<i64>,
+    searched: &mut usize,
+    summary: &mut AuditSummary,
+) {
     if active_queue_episode_ids.contains(&episode_id) {
         info!(
             "Sonarr language audit skipping redownload for episode {} because it already has an active queue item.",
@@ -632,6 +749,14 @@ impl ApiClient {
     }
 
     fn sonarr_inventory_episode_files(&self) -> Result<Vec<(i64, Value)>> {
+        Ok(self
+            .sonarr_inventory_episode_file_items()?
+            .into_iter()
+            .map(|item| (item.episode_id, item.episode_file))
+            .collect())
+    }
+
+    fn sonarr_inventory_episode_file_items(&self) -> Result<Vec<SonarrInventoryItem>> {
         let series = self
             .get(&format!("{}/api/v3/series", self.base_url))?
             .as_array()
@@ -661,12 +786,25 @@ impl ApiClient {
                 let Some(file_id) = episode.get("episodeFileId").and_then(Value::as_i64) else {
                     continue;
                 };
+                let air_day = episode
+                    .get("airDateUtc")
+                    .or_else(|| episode.get("airDate"))
+                    .and_then(Value::as_str)
+                    .and_then(iso_day_number);
                 if let Some(file) = episode.get("episodeFile").filter(|file| file.is_object()) {
-                    out.push((episode_id, file.clone()));
+                    out.push(SonarrInventoryItem {
+                        episode_id,
+                        episode_file: file.clone(),
+                        air_day,
+                    });
                     continue;
                 }
                 match self.sonarr_episode_file(file_id) {
-                    Ok(file) => out.push((episode_id, file)),
+                    Ok(file) => out.push(SonarrInventoryItem {
+                        episode_id,
+                        episode_file: file,
+                        air_day,
+                    }),
                     Err(err) => warn!(
                         "Sonarr inventory language audit could not fetch episode file {} for episode {}: {}",
                         file_id, episode_id, err
@@ -2534,6 +2672,98 @@ mod tests {
 
         assert_eq!(summary.checked, 1);
         assert_eq!(summary.missing, 1);
+        assert_eq!(summary.searched, 1);
+        assert_eq!(summary.no_candidate, 1);
+        queue.assert();
+        series.assert();
+        episodes.assert();
+        history.assert();
+        search.assert();
+    }
+
+    #[test]
+    fn sonarr_latest_missing_audit_searches_newest_missing_episode_first() {
+        let mut server = mockito::Server::new();
+        let queue = mock_empty_queue(&mut server);
+        let series = server
+            .mock("GET", "/api/v3/series")
+            .with_status(200)
+            .with_body(json!([{ "id": 1, "title": "Example" }]).to_string())
+            .create();
+        let episodes = server
+            .mock("GET", "/api/v3/episode")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(
+                json!([
+                    {
+                        "id": 77,
+                        "seriesId": 1,
+                        "hasFile": true,
+                        "airDateUtc": "2026-01-01T00:00:00Z",
+                        "episodeFileId": 555,
+                        "episodeFile": {
+                            "id": 555,
+                            "path": "/media/old.mkv",
+                            "mediaInfo": { "audioLanguages": "jpn", "subtitles": "eng" }
+                        }
+                    },
+                    {
+                        "id": 78,
+                        "seriesId": 1,
+                        "hasFile": true,
+                        "airDateUtc": "2026-02-01T00:00:00Z",
+                        "episodeFileId": 556,
+                        "episodeFile": {
+                            "id": 556,
+                            "path": "/media/new.mkv",
+                            "mediaInfo": { "audioLanguages": "jpn", "subtitles": "eng" }
+                        }
+                    }
+                ])
+                .to_string(),
+            )
+            .create();
+        let history = server
+            .mock("GET", "/api/v3/history")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "records": [] }).to_string())
+            .create();
+        let search = server
+            .mock("GET", "/api/v3/release")
+            .match_query(Matcher::UrlEncoded("episodeId".into(), "78".into()))
+            .with_status(200)
+            .with_body(json!([]).to_string())
+            .create();
+
+        let summary = run_sonarr_language_audit(
+            &ApiSettings {
+                url: Some(server.url()),
+                api_key: Some("test-key".to_string()),
+            },
+            &LanguageRequirements {
+                enabled: true,
+                audio: vec!["eng".to_string(), "jpn".to_string()],
+                subtitles: vec!["eng".to_string()],
+            },
+            RedownloadOptions {
+                dry_run: true,
+                candidate_policy: ServarrLanguageCandidatePolicy::Strict,
+            },
+            AuditOptions {
+                scope: ServarrLanguageAuditScope::LatestMissing,
+                lookback_days: 30,
+                max_searches: 1,
+                no_candidate_cooldown_days: 0,
+                episode_ids: Vec::new(),
+                untagged_retag: UntaggedRetagOptions::default(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.checked, 2);
+        assert_eq!(summary.missing, 2);
         assert_eq!(summary.searched, 1);
         assert_eq!(summary.no_candidate, 1);
         queue.assert();

--- a/src/types.rs
+++ b/src/types.rs
@@ -115,6 +115,8 @@ pub(crate) enum ServarrLanguageAuditScope {
     History,
     /// Inspect the current library inventory instead of only recently imported items.
     Inventory,
+    /// Inspect Sonarr inventory, then search the newest aired missing-language episodes first.
+    LatestMissing,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- add a Sonarr-only `latest-missing` language audit scope
- inspect current inventory, filter to non-compliant episode files, then search newest aired missing-language episodes first
- document the new mode and update config parsing coverage

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -q servarr::api::tests::sonarr_latest_missing_audit_searches_newest_missing_episode_first` *(blocked locally: project expects FFmpeg 8/vcpkg; system FFmpeg 6 headers fail rusty_ffmpeg compile)*
