### PR TITLE
Prepare 1.1.0-beta.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.1.0-beta.5] - 2026-07-02
 
-### Servarr Language Audit
+### Language Audit Prioritization
 
-- Added Sonarr `latest-missing` language audit scope to prioritize newest aired non-compliant episode files before older inventory backlog.
+- Added Sonarr `latest-missing` language audit scope to prioritize newest aired
+  non-compliant episode files before older inventory backlog.
 - Documented the newest-missing audit runbook and command reference.
 
 ## [1.1.0-beta.4] - 2026-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0-beta.5] - 2026-07-02
+
+### Servarr Language Audit
+
+- Added Sonarr `latest-missing` language audit scope to prioritize newest aired non-compliant episode files before older inventory backlog.
+- Documented the newest-missing audit runbook and command reference.
+
 ## [1.1.0-beta.4] - 2026-06-27
 
 ### Servarr Language Audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "1.1.0-beta.4"
+version = "1.1.0-beta.5"
 edition = "2021"
 
 


### PR DESCRIPTION
## Problem

PR #158 added the Sonarr latest-missing language audit scope after v1.1.0-beta.4 was tagged, so the newest audit behavior needs a release tag.

## What's changed

This bumps the crate to 1.1.0-beta.5 and adds release notes for latest-missing Sonarr language audits.

Checked with `cargo fmt --check` and `git diff --check`.
