### PR TITLE
Add latest-missing no-candidate cooldown override

### DIFF
--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -73,6 +73,8 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
 - `--servarr-language-audit-max-searches <N>` cap release searches per audit run
 - `--servarr-language-audit-no-candidate-cooldown-days <D>` skip items
   with a recent no-candidate audit result for `D` days; `0` disables this
+- `--servarr-language-audit-latest-missing-no-candidate-cooldown-days <D>`
+  override the no-candidate cooldown for `latest-missing` audits
 - `--servarr-language-audit-episode-ids <IDS>` comma-separated Sonarr episode
   IDs to audit instead of the full scope
 - `--servarr-language-check` enable pre-conversion language checks for Arr

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -191,8 +191,12 @@ and spend the search budget on recent delayed dubs/subs before older backlog.
 If early inventory items repeatedly return no approved replacement, set
 `--servarr-language-audit-no-candidate-cooldown-days` (or
 `servarr_language_audit_no_candidate_cooldown_days`) so those no-candidate items
-are not release-searched again until the cooldown expires. DPN stores this
-best-effort state in
+are not release-searched again until the cooldown expires. For weekly delayed
+sub/dub drops, use
+`--servarr-language-audit-latest-missing-no-candidate-cooldown-days` (or
+`servarr_language_audit_latest_missing_no_candidate_cooldown_days`) to give
+`latest-missing` a shorter retry window than broad backlog sweeps. DPN stores
+this best-effort state in
 `$XDG_CACHE_HOME/direct-play-nice/servarr-language-no-candidate-cache.json` or
 `~/.cache/direct-play-nice/servarr-language-no-candidate-cache.json`; override it
 with `DIRECT_PLAY_NICE_LANGUAGE_NO_CANDIDATE_CACHE`. This lets later inventory
@@ -248,6 +252,7 @@ observable batches. A safe operator workflow is:
      --servarr-language-audit \
      --servarr-language-audit-scope latest-missing \
      --servarr-language-audit-max-searches 25 \
+     --servarr-language-audit-latest-missing-no-candidate-cooldown-days 2 \
      --servarr-language-dry-run
    ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     pub servarr_language_audit_lookback_days: Option<u32>,
     pub servarr_language_audit_max_searches: Option<usize>,
     pub servarr_language_audit_no_candidate_cooldown_days: Option<u32>,
+    pub servarr_language_audit_latest_missing_no_candidate_cooldown_days: Option<u32>,
     pub servarr_language_audit_episode_ids: Option<String>,
     pub servarr_language_check: Option<bool>,
     pub required_audio_languages: Option<String>,
@@ -271,6 +272,7 @@ mod tests {
             servarr_language_audit_lookback_days = 30
             servarr_language_audit_max_searches = 20
             servarr_language_audit_no_candidate_cooldown_days = 14
+            servarr_language_audit_latest_missing_no_candidate_cooldown_days = 2
             servarr_language_audit_episode_ids = "1,2,3"
             servarr_language_check = true
             required_audio_languages = "eng,jpn"
@@ -296,6 +298,10 @@ mod tests {
         assert_eq!(
             cfg.servarr_language_audit_no_candidate_cooldown_days,
             Some(14)
+        );
+        assert_eq!(
+            cfg.servarr_language_audit_latest_missing_no_candidate_cooldown_days,
+            Some(2)
         );
         assert_eq!(
             cfg.servarr_language_audit_episode_ids.as_deref(),

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -169,6 +169,15 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(
+        matches,
+        "servarr_language_audit_latest_missing_no_candidate_cooldown_days",
+    ) {
+        if let Some(days) = cfg.servarr_language_audit_latest_missing_no_candidate_cooldown_days {
+            args.servarr_language_audit_latest_missing_no_candidate_cooldown_days = Some(days);
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_audit_episode_ids") {
         if let Some(ids) = cfg.servarr_language_audit_episode_ids.as_ref() {
             args.servarr_language_audit_episode_ids = Some(ids.clone());
@@ -372,6 +381,7 @@ mod tests {
             servarr_language_audit_lookback_days: Some(30),
             servarr_language_audit_max_searches: Some(20),
             servarr_language_audit_no_candidate_cooldown_days: Some(14),
+            servarr_language_audit_latest_missing_no_candidate_cooldown_days: Some(2),
             servarr_language_audit_episode_ids: Some("77,88".to_string()),
             servarr_language_check: Some(true),
             required_audio_languages: Some("eng,jpn".to_string()),
@@ -395,6 +405,10 @@ mod tests {
         assert_eq!(args.servarr_language_audit_lookback_days, 30);
         assert_eq!(args.servarr_language_audit_max_searches, 20);
         assert_eq!(args.servarr_language_audit_no_candidate_cooldown_days, 14);
+        assert_eq!(
+            args.servarr_language_audit_latest_missing_no_candidate_cooldown_days,
+            Some(2)
+        );
         assert_eq!(
             args.servarr_language_audit_episode_ids.as_deref(),
             Some("77,88")

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -244,6 +244,14 @@ pub(crate) struct Args {
     )]
     pub(crate) servarr_language_audit_no_candidate_cooldown_days: u32,
 
+    /// Override no-candidate cooldown days for latest-missing audits. Defaults to the general cooldown.
+    #[arg(
+        long = "servarr-language-audit-latest-missing-no-candidate-cooldown-days",
+        value_name = "DAYS",
+        id = "servarr_language_audit_latest_missing_no_candidate_cooldown_days"
+    )]
+    pub(crate) servarr_language_audit_latest_missing_no_candidate_cooldown_days: Option<u32>,
+
     /// Optional comma-separated Sonarr episode IDs to audit instead of the full scope.
     #[arg(
         long = "servarr-language-audit-episode-ids",

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -46,6 +46,7 @@ pub struct AuditOptions {
     pub lookback_days: u32,
     pub max_searches: usize,
     pub no_candidate_cooldown_days: u32,
+    pub latest_missing_no_candidate_cooldown_days: Option<u32>,
     pub episode_ids: Vec<i64>,
     pub untagged_retag: UntaggedRetagOptions,
 }
@@ -57,6 +58,7 @@ impl Default for AuditOptions {
             lookback_days: 30,
             max_searches: 20,
             no_candidate_cooldown_days: 0,
+            latest_missing_no_candidate_cooldown_days: None,
             episode_ids: Vec::new(),
             untagged_retag: UntaggedRetagOptions::default(),
         }
@@ -294,6 +296,9 @@ fn run_sonarr_latest_missing_language_audit(
             .then_with(|| right.episode_id.cmp(&left.episode_id))
     });
 
+    let no_candidate_cooldown_days = audit_options
+        .latest_missing_no_candidate_cooldown_days
+        .unwrap_or(audit_options.no_candidate_cooldown_days);
     let mut searched = 0usize;
     for item in missing_items {
         if searched >= audit_options.max_searches {
@@ -306,7 +311,7 @@ fn run_sonarr_latest_missing_language_audit(
             requirements,
             redownload_options,
             audit_options.max_searches,
-            audit_options.no_candidate_cooldown_days,
+            no_candidate_cooldown_days,
             active_queue_episode_ids,
             &mut searched,
             &mut summary,
@@ -614,6 +619,9 @@ fn run_radarr_latest_missing_language_audit(
             .then_with(|| right.movie_id.cmp(&left.movie_id))
     });
 
+    let no_candidate_cooldown_days = audit_options
+        .latest_missing_no_candidate_cooldown_days
+        .unwrap_or(audit_options.no_candidate_cooldown_days);
     let mut searched = 0usize;
     for item in missing_items {
         if searched >= audit_options.max_searches {
@@ -626,7 +634,7 @@ fn run_radarr_latest_missing_language_audit(
             requirements,
             redownload_options,
             audit_options.max_searches,
-            audit_options.no_candidate_cooldown_days,
+            no_candidate_cooldown_days,
             active_queue_movie_ids,
             &mut searched,
             &mut summary,
@@ -2818,6 +2826,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -2925,6 +2934,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3018,6 +3028,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 1,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3110,6 +3121,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 1,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3183,6 +3195,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3279,6 +3292,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3354,6 +3368,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3418,6 +3433,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3516,6 +3532,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3607,6 +3624,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3683,6 +3701,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3756,6 +3775,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3844,6 +3864,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3920,6 +3941,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3974,6 +3996,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4025,6 +4048,7 @@ mod tests {
                 lookback_days: 30,
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
+                latest_missing_no_candidate_cooldown_days: None,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -244,6 +244,8 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
             lookback_days: args.servarr_language_audit_lookback_days,
             max_searches: args.servarr_language_audit_max_searches,
             no_candidate_cooldown_days: args.servarr_language_audit_no_candidate_cooldown_days,
+            latest_missing_no_candidate_cooldown_days: args
+                .servarr_language_audit_latest_missing_no_candidate_cooldown_days,
             episode_ids: parse_optional_i64_list(
                 args.servarr_language_audit_episode_ids.as_deref(),
             )?,


### PR DESCRIPTION
## Summary
- add a configurable latest-missing-specific no-candidate cooldown override
- keep broad inventory cooldowns long while allowing recent delayed dub/sub audits to retry sooner
- document the new CLI/config knob and show it in the latest-missing runbook

## Testing
- cargo fmt --check
- git diff --check
- cargo check is blocked locally by the workspace FFmpeg/vcpkg setup; CI/plex host should exercise FFmpeg 8
