### PR TITLE
Clear bad Sonarr language-upgrade queue items

### DIFF
--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -75,6 +75,8 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
   with a recent no-candidate audit result for `D` days; `0` disables this
 - `--servarr-language-audit-latest-missing-no-candidate-cooldown-days <D>`
   override the no-candidate cooldown for `latest-missing` audits
+- `--servarr-language-audit-stale-queue-days <D>` remove and blocklist zero-size
+  torrent queue items older than `D` days; `0` disables this
 - `--servarr-language-audit-episode-ids <IDS>` comma-separated Sonarr episode
   IDs to audit instead of the full scope
 - `--servarr-language-check` enable pre-conversion language checks for Arr

--- a/docs/src/command-reference.md
+++ b/docs/src/command-reference.md
@@ -77,6 +77,8 @@ direct_play_nice [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
   override the no-candidate cooldown for `latest-missing` audits
 - `--servarr-language-audit-stale-queue-days <D>` remove and blocklist zero-size
   torrent queue items older than `D` days; `0` disables this
+- `--servarr-language-audit-stale-queue-max-removals <N>` cap stale queue
+  removals per audit run; `0` means no cap
 - `--servarr-language-audit-episode-ids <IDS>` comma-separated Sonarr episode
   IDs to audit instead of the full scope
 - `--servarr-language-check` enable pre-conversion language checks for Arr

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -215,10 +215,16 @@ language and the pending file satisfies the language policy.
 
 Sonarr auto-grabs are limited to releases that map back to the single requested
 episode; multi-episode and season-pack results are skipped even when their titles
-contain strong language hints. Keep dry-run enabled while reviewing reports;
-remove `--servarr-language-dry-run` only when you want DPN to grab selected
-language-upgrade candidates, blocklist the old history item, and force-import
-eligible pending replacements.
+contain strong language hints. During audits, DPN can also clean up hopeless
+queue entries: completed warning items with invalid season/episode or wrong
+multi-episode mappings are removed and blocklisted, while quality-only warnings
+are left for possible force-import. Set
+`--servarr-language-audit-stale-queue-days` to also remove and blocklist
+zero-size torrent queue items that have not acquired metadata after the given
+number of days. Keep dry-run enabled while reviewing reports; remove
+`--servarr-language-dry-run` only when you want DPN to grab selected
+language-upgrade candidates, blocklist the old history item, force-import
+eligible pending replacements, and clean bad queue entries.
 
 This feature assumes DPN is the authority for language upgrades. To avoid Arr
 and DPN fighting each other, keep ordinary Arr quality-only upgrades conservative

--- a/docs/src/servarr.md
+++ b/docs/src/servarr.md
@@ -221,7 +221,10 @@ multi-episode mappings are removed and blocklisted, while quality-only warnings
 are left for possible force-import. Set
 `--servarr-language-audit-stale-queue-days` to also remove and blocklist
 zero-size torrent queue items that have not acquired metadata after the given
-number of days. Keep dry-run enabled while reviewing reports; remove
+number of days. DPN immediately searches for a replacement after stale cleanup,
+preferring non-torrent candidates when possible; use
+`--servarr-language-audit-stale-queue-max-removals` to cap churn per run. Keep
+dry-run enabled while reviewing reports; remove
 `--servarr-language-dry-run` only when you want DPN to grab selected
 language-upgrade candidates, blocklist the old history item, force-import
 eligible pending replacements, and clean bad queue entries.

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,7 @@ pub struct Config {
     pub servarr_language_audit_no_candidate_cooldown_days: Option<u32>,
     pub servarr_language_audit_latest_missing_no_candidate_cooldown_days: Option<u32>,
     pub servarr_language_audit_stale_queue_days: Option<u32>,
+    pub servarr_language_audit_stale_queue_max_removals: Option<usize>,
     pub servarr_language_audit_episode_ids: Option<String>,
     pub servarr_language_check: Option<bool>,
     pub required_audio_languages: Option<String>,
@@ -275,6 +276,7 @@ mod tests {
             servarr_language_audit_no_candidate_cooldown_days = 14
             servarr_language_audit_latest_missing_no_candidate_cooldown_days = 2
             servarr_language_audit_stale_queue_days = 2
+            servarr_language_audit_stale_queue_max_removals = 25
             servarr_language_audit_episode_ids = "1,2,3"
             servarr_language_check = true
             required_audio_languages = "eng,jpn"
@@ -306,6 +308,10 @@ mod tests {
             Some(2)
         );
         assert_eq!(cfg.servarr_language_audit_stale_queue_days, Some(2));
+        assert_eq!(
+            cfg.servarr_language_audit_stale_queue_max_removals,
+            Some(25)
+        );
         assert_eq!(
             cfg.servarr_language_audit_episode_ids.as_deref(),
             Some("1,2,3")

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct Config {
     pub servarr_language_audit_max_searches: Option<usize>,
     pub servarr_language_audit_no_candidate_cooldown_days: Option<u32>,
     pub servarr_language_audit_latest_missing_no_candidate_cooldown_days: Option<u32>,
+    pub servarr_language_audit_stale_queue_days: Option<u32>,
     pub servarr_language_audit_episode_ids: Option<String>,
     pub servarr_language_check: Option<bool>,
     pub required_audio_languages: Option<String>,
@@ -273,6 +274,7 @@ mod tests {
             servarr_language_audit_max_searches = 20
             servarr_language_audit_no_candidate_cooldown_days = 14
             servarr_language_audit_latest_missing_no_candidate_cooldown_days = 2
+            servarr_language_audit_stale_queue_days = 2
             servarr_language_audit_episode_ids = "1,2,3"
             servarr_language_check = true
             required_audio_languages = "eng,jpn"
@@ -303,6 +305,7 @@ mod tests {
             cfg.servarr_language_audit_latest_missing_no_candidate_cooldown_days,
             Some(2)
         );
+        assert_eq!(cfg.servarr_language_audit_stale_queue_days, Some(2));
         assert_eq!(
             cfg.servarr_language_audit_episode_ids.as_deref(),
             Some("1,2,3")

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -178,6 +178,12 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_audit_stale_queue_days") {
+        if let Some(days) = cfg.servarr_language_audit_stale_queue_days {
+            args.servarr_language_audit_stale_queue_days = days;
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_audit_episode_ids") {
         if let Some(ids) = cfg.servarr_language_audit_episode_ids.as_ref() {
             args.servarr_language_audit_episode_ids = Some(ids.clone());
@@ -382,6 +388,7 @@ mod tests {
             servarr_language_audit_max_searches: Some(20),
             servarr_language_audit_no_candidate_cooldown_days: Some(14),
             servarr_language_audit_latest_missing_no_candidate_cooldown_days: Some(2),
+            servarr_language_audit_stale_queue_days: Some(2),
             servarr_language_audit_episode_ids: Some("77,88".to_string()),
             servarr_language_check: Some(true),
             required_audio_languages: Some("eng,jpn".to_string()),
@@ -409,6 +416,7 @@ mod tests {
             args.servarr_language_audit_latest_missing_no_candidate_cooldown_days,
             Some(2)
         );
+        assert_eq!(args.servarr_language_audit_stale_queue_days, 2);
         assert_eq!(
             args.servarr_language_audit_episode_ids.as_deref(),
             Some("77,88")

--- a/src/config_merge.rs
+++ b/src/config_merge.rs
@@ -184,6 +184,12 @@ pub(crate) fn apply_config_overrides(args: &mut Args, cfg: &config::Config, matc
         }
     }
 
+    if !cli_value_provided(matches, "servarr_language_audit_stale_queue_max_removals") {
+        if let Some(max_removals) = cfg.servarr_language_audit_stale_queue_max_removals {
+            args.servarr_language_audit_stale_queue_max_removals = max_removals;
+        }
+    }
+
     if !cli_value_provided(matches, "servarr_language_audit_episode_ids") {
         if let Some(ids) = cfg.servarr_language_audit_episode_ids.as_ref() {
             args.servarr_language_audit_episode_ids = Some(ids.clone());
@@ -389,6 +395,7 @@ mod tests {
             servarr_language_audit_no_candidate_cooldown_days: Some(14),
             servarr_language_audit_latest_missing_no_candidate_cooldown_days: Some(2),
             servarr_language_audit_stale_queue_days: Some(2),
+            servarr_language_audit_stale_queue_max_removals: Some(25),
             servarr_language_audit_episode_ids: Some("77,88".to_string()),
             servarr_language_check: Some(true),
             required_audio_languages: Some("eng,jpn".to_string()),
@@ -417,6 +424,7 @@ mod tests {
             Some(2)
         );
         assert_eq!(args.servarr_language_audit_stale_queue_days, 2);
+        assert_eq!(args.servarr_language_audit_stale_queue_max_removals, 25);
         assert_eq!(
             args.servarr_language_audit_episode_ids.as_deref(),
             Some("77,88")

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -260,6 +260,14 @@ pub(crate) struct Args {
     )]
     pub(crate) servarr_language_audit_stale_queue_days: u32,
 
+    /// Maximum stale zero-size queue items to remove per audit run. Zero means no cap.
+    #[arg(
+        long = "servarr-language-audit-stale-queue-max-removals",
+        default_value_t = 0,
+        id = "servarr_language_audit_stale_queue_max_removals"
+    )]
+    pub(crate) servarr_language_audit_stale_queue_max_removals: usize,
+
     /// Optional comma-separated Sonarr episode IDs to audit instead of the full scope.
     #[arg(
         long = "servarr-language-audit-episode-ids",

--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -252,6 +252,14 @@ pub(crate) struct Args {
     )]
     pub(crate) servarr_language_audit_latest_missing_no_candidate_cooldown_days: Option<u32>,
 
+    /// Days before zero-size torrent queue items are considered stale and blocklisted. Zero disables cleanup.
+    #[arg(
+        long = "servarr-language-audit-stale-queue-days",
+        default_value_t = 0,
+        id = "servarr_language_audit_stale_queue_days"
+    )]
+    pub(crate) servarr_language_audit_stale_queue_days: u32,
+
     /// Optional comma-separated Sonarr episode IDs to audit instead of the full scope.
     #[arg(
         long = "servarr-language-audit-episode-ids",

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -928,16 +928,6 @@ impl ApiClient {
         })
     }
 
-    fn redownload_for_target(
-        &self,
-        target: Target,
-        history_id: i64,
-        requirements: &LanguageRequirements,
-        options: RedownloadOptions,
-    ) -> Result<RedownloadOutcome> {
-        self.redownload_for_target_with_preference(target, history_id, requirements, options, false)
-    }
-
     fn redownload_for_target_with_preference(
         &self,
         target: Target,

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -1512,6 +1512,7 @@ impl ApiClient {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn sonarr_remove_bad_queue_items(
         &self,
         records: &[Value],
@@ -1786,6 +1787,7 @@ impl ApiClient {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn apply_audit_redownload_outcome_with_preference(
         &self,
         target: Target,

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -138,17 +138,21 @@ pub fn run_sonarr_language_audit(
 ) -> Result<AuditSummary> {
     let client = ApiClient::from_settings(IntegrationKind::Sonarr, settings)?;
     let queue_records = client.sonarr_queue_records()?;
+    let mut summary = AuditSummary::default();
     client.sonarr_remove_bad_queue_items(
-        &queue_records,
-        redownload_options,
-        audit_options.stale_queue_days,
-    )?;
-    let active_queue_episode_ids = sonarr_active_queue_episode_ids(&queue_records);
-    let mut summary = client.sonarr_force_import_pending_language_upgrades(
         &queue_records,
         requirements,
         redownload_options,
+        audit_options.stale_queue_days,
+        audit_options.no_candidate_cooldown_days,
+        &mut summary,
     )?;
+    let active_queue_episode_ids = sonarr_active_queue_episode_ids(&queue_records);
+    summary.merge(client.sonarr_force_import_pending_language_upgrades(
+        &queue_records,
+        requirements,
+        redownload_options,
+    )?);
     let audit_summary = match audit_options.scope {
         ServarrLanguageAuditScope::History => run_sonarr_history_language_audit(
             &client,
@@ -1505,8 +1509,11 @@ impl ApiClient {
     fn sonarr_remove_bad_queue_items(
         &self,
         records: &[Value],
+        requirements: &LanguageRequirements,
         options: RedownloadOptions,
         stale_queue_days: u32,
+        no_candidate_cooldown_days: u32,
+        summary: &mut AuditSummary,
     ) -> Result<()> {
         for queue_item in records {
             let Some(reason) = sonarr_bad_queue_reason(queue_item, stale_queue_days) else {
@@ -1524,15 +1531,67 @@ impl ApiClient {
                     "Sonarr language audit dry-run: would remove and blocklist bad queue item {} ('{}'): {}.",
                     queue_id, title, reason
                 );
-                continue;
+            } else {
+                self.sonarr_delete_queue_item_with_options(queue_id, true, true)?;
+                info!(
+                    "Sonarr language audit removed and blocklisted bad queue item {} ('{}'): {}.",
+                    queue_id, title, reason
+                );
             }
-            self.sonarr_delete_queue_item_with_options(queue_id, true, true)?;
-            info!(
-                "Sonarr language audit removed and blocklisted bad queue item {} ('{}'): {}.",
-                queue_id, title, reason
-            );
+
+            if reason == "stale zero-size torrent queue item" {
+                for episode_id in sonarr_queue_item_episode_ids(queue_item) {
+                    self.sonarr_search_replacement_after_bad_queue_item(
+                        episode_id,
+                        requirements,
+                        options,
+                        no_candidate_cooldown_days,
+                        summary,
+                    );
+                }
+            }
         }
         Ok(())
+    }
+
+    fn sonarr_search_replacement_after_bad_queue_item(
+        &self,
+        episode_id: i64,
+        requirements: &LanguageRequirements,
+        options: RedownloadOptions,
+        no_candidate_cooldown_days: u32,
+        summary: &mut AuditSummary,
+    ) {
+        summary.missing += 1;
+        summary.searched += 1;
+        let history_id = match self.sonarr_latest_import_history_id(episode_id) {
+            Ok(Some(id)) => id,
+            Ok(None) if options.dry_run => 0,
+            Ok(None) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr language audit removed stale queue item for episode {} but could not identify import history; refusing replacement search.",
+                    episode_id
+                );
+                return;
+            }
+            Err(err) => {
+                summary.errors += 1;
+                warn!(
+                    "Sonarr language audit removed stale queue item for episode {} but could not fetch import history: {}",
+                    episode_id, err
+                );
+                return;
+            }
+        };
+        self.apply_audit_redownload_outcome(
+            Target::SonarrEpisode { episode_id },
+            history_id,
+            requirements,
+            options,
+            no_candidate_cooldown_days,
+            summary,
+        );
     }
 
     fn radarr_movie(&self, movie_id: i64) -> Result<Value> {

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -47,6 +47,7 @@ pub struct AuditOptions {
     pub max_searches: usize,
     pub no_candidate_cooldown_days: u32,
     pub latest_missing_no_candidate_cooldown_days: Option<u32>,
+    pub stale_queue_days: u32,
     pub episode_ids: Vec<i64>,
     pub untagged_retag: UntaggedRetagOptions,
 }
@@ -59,6 +60,7 @@ impl Default for AuditOptions {
             max_searches: 20,
             no_candidate_cooldown_days: 0,
             latest_missing_no_candidate_cooldown_days: None,
+            stale_queue_days: 0,
             episode_ids: Vec::new(),
             untagged_retag: UntaggedRetagOptions::default(),
         }
@@ -136,7 +138,11 @@ pub fn run_sonarr_language_audit(
 ) -> Result<AuditSummary> {
     let client = ApiClient::from_settings(IntegrationKind::Sonarr, settings)?;
     let queue_records = client.sonarr_queue_records()?;
-    client.sonarr_remove_bad_queue_items(&queue_records, redownload_options)?;
+    client.sonarr_remove_bad_queue_items(
+        &queue_records,
+        redownload_options,
+        audit_options.stale_queue_days,
+    )?;
     let active_queue_episode_ids = sonarr_active_queue_episode_ids(&queue_records);
     let mut summary = client.sonarr_force_import_pending_language_upgrades(
         &queue_records,
@@ -1500,9 +1506,10 @@ impl ApiClient {
         &self,
         records: &[Value],
         options: RedownloadOptions,
+        stale_queue_days: u32,
     ) -> Result<()> {
         for queue_item in records {
-            let Some(reason) = sonarr_bad_queue_reason(queue_item) else {
+            let Some(reason) = sonarr_bad_queue_reason(queue_item, stale_queue_days) else {
                 continue;
             };
             let Some(queue_id) = queue_item.get("id").and_then(Value::as_i64) else {
@@ -1873,7 +1880,7 @@ fn sonarr_active_queue_episode_ids(records: &[Value]) -> BTreeSet<i64> {
         .collect()
 }
 
-fn sonarr_bad_queue_reason(queue_item: &Value) -> Option<&'static str> {
+fn sonarr_bad_queue_reason(queue_item: &Value, stale_queue_days: u32) -> Option<&'static str> {
     let status = queue_item
         .get("status")
         .and_then(Value::as_str)
@@ -1882,6 +1889,23 @@ fn sonarr_bad_queue_reason(queue_item: &Value) -> Option<&'static str> {
         .get("trackedDownloadStatus")
         .and_then(Value::as_str)
         .unwrap_or_default();
+    if status == "queued"
+        && queue_item
+            .get("trackedDownloadState")
+            .and_then(Value::as_str)
+            == Some("downloading")
+        && tracked_status == "ok"
+        && queue_item.get("protocol").and_then(Value::as_str) == Some("torrent")
+        && queue_item.get("size").and_then(Value::as_i64).unwrap_or(0) == 0
+        && queue_item
+            .get("sizeleft")
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            == 0
+        && queue_item_is_stale(queue_item, stale_queue_days)
+    {
+        return Some("stale zero-size torrent queue item");
+    }
     if status != "completed" || tracked_status != "warning" {
         return None;
     }
@@ -1899,6 +1923,20 @@ fn sonarr_bad_queue_reason(queue_item: &Value) -> Option<&'static str> {
         return Some("episode mismatch or multi-episode pack");
     }
     None
+}
+
+fn queue_item_is_stale(queue_item: &Value, stale_queue_days: u32) -> bool {
+    if stale_queue_days == 0 {
+        return false;
+    }
+    let Some(added_day) = queue_item
+        .get("added")
+        .and_then(Value::as_str)
+        .and_then(iso_day_number)
+    else {
+        return false;
+    };
+    current_day_number().saturating_sub(added_day) >= stale_queue_days as i64
 }
 
 fn queue_status_message_text(queue_item: &Value) -> String {
@@ -2726,7 +2764,7 @@ mod tests {
             }]
         });
         assert_eq!(
-            sonarr_bad_queue_reason(&invalid),
+            sonarr_bad_queue_reason(&invalid, 0),
             Some("invalid season or episode")
         );
 
@@ -2739,7 +2777,7 @@ mod tests {
             }]
         });
         assert_eq!(
-            sonarr_bad_queue_reason(&mismatch),
+            sonarr_bad_queue_reason(&mismatch, 0),
             Some("episode mismatch or multi-episode pack")
         );
 
@@ -2751,7 +2789,22 @@ mod tests {
                 "messages": ["Not an upgrade for existing episode file(s). Existing quality: Bluray-1080p. New Quality Bluray-720p."]
             }]
         });
-        assert_eq!(sonarr_bad_queue_reason(&quality), None);
+        assert_eq!(sonarr_bad_queue_reason(&quality, 0), None);
+
+        let stale = json!({
+            "status": "queued",
+            "trackedDownloadStatus": "ok",
+            "trackedDownloadState": "downloading",
+            "protocol": "torrent",
+            "size": 0,
+            "sizeleft": 0,
+            "added": "2000-01-01T00:00:00Z"
+        });
+        assert_eq!(
+            sonarr_bad_queue_reason(&stale, 2),
+            Some("stale zero-size torrent queue item")
+        );
+        assert_eq!(sonarr_bad_queue_reason(&stale, 0), None);
     }
 
     #[test]
@@ -2958,6 +3011,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3066,6 +3120,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3160,6 +3215,7 @@ mod tests {
                 max_searches: 1,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3253,6 +3309,7 @@ mod tests {
                 max_searches: 1,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3327,6 +3384,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3424,6 +3482,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3500,6 +3559,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3565,6 +3625,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3664,6 +3725,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3756,6 +3818,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3833,6 +3896,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3907,6 +3971,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3996,6 +4061,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4073,6 +4139,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4128,6 +4195,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4180,6 +4248,7 @@ mod tests {
                 max_searches: 10,
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
+                stale_queue_days: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -48,6 +48,7 @@ pub struct AuditOptions {
     pub no_candidate_cooldown_days: u32,
     pub latest_missing_no_candidate_cooldown_days: Option<u32>,
     pub stale_queue_days: u32,
+    pub stale_queue_max_removals: usize,
     pub episode_ids: Vec<i64>,
     pub untagged_retag: UntaggedRetagOptions,
 }
@@ -61,6 +62,7 @@ impl Default for AuditOptions {
             no_candidate_cooldown_days: 0,
             latest_missing_no_candidate_cooldown_days: None,
             stale_queue_days: 0,
+            stale_queue_max_removals: 0,
             episode_ids: Vec::new(),
             untagged_retag: UntaggedRetagOptions::default(),
         }
@@ -144,6 +146,7 @@ pub fn run_sonarr_language_audit(
         requirements,
         redownload_options,
         audit_options.stale_queue_days,
+        audit_options.stale_queue_max_removals,
         audit_options.no_candidate_cooldown_days,
         &mut summary,
     )?;
@@ -811,6 +814,7 @@ pub fn trigger_verified_redownload(
         target,
         requirements,
         options.candidate_policy,
+        false,
     ) else {
         return Ok(RedownloadOutcome::NoVerifiedRelease {
             reason: format!(
@@ -931,12 +935,24 @@ impl ApiClient {
         requirements: &LanguageRequirements,
         options: RedownloadOptions,
     ) -> Result<RedownloadOutcome> {
+        self.redownload_for_target_with_preference(target, history_id, requirements, options, false)
+    }
+
+    fn redownload_for_target_with_preference(
+        &self,
+        target: Target,
+        history_id: i64,
+        requirements: &LanguageRequirements,
+        options: RedownloadOptions,
+        prefer_non_torrent: bool,
+    ) -> Result<RedownloadOutcome> {
         let releases = self.search_releases(&target)?;
         let Some(release) = select_verified_release_for_target(
             &releases,
             target,
             requirements,
             options.candidate_policy,
+            prefer_non_torrent,
         ) else {
             return Ok(RedownloadOutcome::NoVerifiedRelease {
                 reason: format!(
@@ -1512,13 +1528,25 @@ impl ApiClient {
         requirements: &LanguageRequirements,
         options: RedownloadOptions,
         stale_queue_days: u32,
+        stale_queue_max_removals: usize,
         no_candidate_cooldown_days: u32,
         summary: &mut AuditSummary,
     ) -> Result<()> {
+        let mut stale_removals = 0usize;
         for queue_item in records {
             let Some(reason) = sonarr_bad_queue_reason(queue_item, stale_queue_days) else {
                 continue;
             };
+            if reason == "stale zero-size torrent queue item"
+                && stale_queue_max_removals > 0
+                && stale_removals >= stale_queue_max_removals
+            {
+                info!(
+                    "Sonarr language audit skipping stale zero-size queue cleanup because max removals ({}) was reached.",
+                    stale_queue_max_removals
+                );
+                continue;
+            }
             let Some(queue_id) = queue_item.get("id").and_then(Value::as_i64) else {
                 continue;
             };
@@ -1540,6 +1568,7 @@ impl ApiClient {
             }
 
             if reason == "stale zero-size torrent queue item" {
+                stale_removals += 1;
                 for episode_id in sonarr_queue_item_episode_ids(queue_item) {
                     self.sonarr_search_replacement_after_bad_queue_item(
                         episode_id,
@@ -1584,12 +1613,13 @@ impl ApiClient {
                 return;
             }
         };
-        self.apply_audit_redownload_outcome(
+        self.apply_audit_redownload_outcome_with_preference(
             Target::SonarrEpisode { episode_id },
             history_id,
             requirements,
             options,
             no_candidate_cooldown_days,
+            true,
             summary,
         );
     }
@@ -1755,9 +1785,36 @@ impl ApiClient {
         no_candidate_cooldown_days: u32,
         summary: &mut AuditSummary,
     ) {
+        self.apply_audit_redownload_outcome_with_preference(
+            target,
+            history_id,
+            requirements,
+            options,
+            no_candidate_cooldown_days,
+            false,
+            summary,
+        );
+    }
+
+    fn apply_audit_redownload_outcome_with_preference(
+        &self,
+        target: Target,
+        history_id: i64,
+        requirements: &LanguageRequirements,
+        options: RedownloadOptions,
+        no_candidate_cooldown_days: u32,
+        prefer_non_torrent: bool,
+        summary: &mut AuditSummary,
+    ) {
         let label = self.kind.label();
         let target_id = target.id();
-        match self.redownload_for_target(target, history_id, requirements, options) {
+        match self.redownload_for_target_with_preference(
+            target,
+            history_id,
+            requirements,
+            options,
+            prefer_non_torrent,
+        ) {
             Ok(RedownloadOutcome::Grabbed { title }) => {
                 summary.grabbed += 1;
                 info!(
@@ -2287,13 +2344,33 @@ fn select_verified_release_for_target<'a>(
     target: Target,
     requirements: &LanguageRequirements,
     policy: ServarrLanguageCandidatePolicy,
+    prefer_non_torrent: bool,
 ) -> Option<&'a Value> {
     releases
         .iter()
         .filter(|release| release_matches_target(release, target))
         .filter(|release| release_can_be_language_upgrade_candidate(release))
         .filter(|release| release_satisfies_languages(release, requirements, policy))
-        .max_by_key(|release| release_score(release))
+        .max_by_key(|release| {
+            (
+                prefer_non_torrent && !release_is_torrent(release),
+                release_score(release),
+            )
+        })
+}
+
+fn release_is_torrent(release: &Value) -> bool {
+    release
+        .get("protocol")
+        .and_then(Value::as_str)
+        .map(|protocol| protocol.eq_ignore_ascii_case("torrent"))
+        .or_else(|| {
+            release
+                .get("protocol")
+                .and_then(Value::as_i64)
+                .map(|id| id == 2)
+        })
+        .unwrap_or(false)
 }
 
 fn release_matches_target(release: &Value, target: Target) -> bool {
@@ -3071,6 +3148,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3180,6 +3258,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3275,6 +3354,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3369,6 +3449,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3444,6 +3525,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3542,6 +3624,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3619,6 +3702,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3685,6 +3769,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: vec![77],
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3785,6 +3870,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3878,6 +3964,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -3956,6 +4043,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4031,6 +4119,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4121,6 +4210,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4199,6 +4289,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4255,6 +4346,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4308,6 +4400,7 @@ mod tests {
                 no_candidate_cooldown_days: 0,
                 latest_missing_no_candidate_cooldown_days: None,
                 stale_queue_days: 0,
+                stale_queue_max_removals: 0,
                 episode_ids: Vec::new(),
                 untagged_retag: UntaggedRetagOptions::default(),
             },
@@ -4512,6 +4605,7 @@ mod tests {
             Target::SonarrEpisode { episode_id: 77 },
             &req,
             ServarrLanguageCandidatePolicy::Strict,
+            false,
         )
         .unwrap();
         assert_eq!(
@@ -4539,6 +4633,7 @@ mod tests {
             Target::SonarrEpisode { episode_id: 77 },
             &req,
             ServarrLanguageCandidatePolicy::Strict,
+            false,
         )
         .is_none());
     }
@@ -4568,6 +4663,7 @@ mod tests {
             Target::SonarrEpisode { episode_id: 77 },
             &req,
             ServarrLanguageCandidatePolicy::Strict,
+            false,
         )
         .is_none());
     }
@@ -4596,7 +4692,8 @@ mod tests {
             &releases,
             Target::RadarrMovie { movie_id: 1 },
             &req,
-            ServarrLanguageCandidatePolicy::CustomFormatOrTitle
+            ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            false,
         )
         .is_some());
     }
@@ -4620,7 +4717,8 @@ mod tests {
             &releases,
             Target::RadarrMovie { movie_id: 1 },
             &req,
-            ServarrLanguageCandidatePolicy::CustomFormatOrTitle
+            ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            false,
         )
         .is_none());
     }
@@ -4689,7 +4787,8 @@ mod tests {
             &releases,
             Target::RadarrMovie { movie_id: 1 },
             &req,
-            ServarrLanguageCandidatePolicy::CustomFormat
+            ServarrLanguageCandidatePolicy::CustomFormat,
+            false,
         )
         .is_some());
     }
@@ -4712,6 +4811,7 @@ mod tests {
             Target::SonarrEpisode { episode_id: 77 },
             &req,
             ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            false,
         )
         .is_none());
     }
@@ -4734,6 +4834,7 @@ mod tests {
             Target::SonarrEpisode { episode_id: 77 },
             &req,
             ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            false,
         )
         .is_some());
     }
@@ -4757,6 +4858,7 @@ mod tests {
             Target::SonarrEpisode { episode_id: 77 },
             &req,
             ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            false,
         )
         .is_some());
     }
@@ -4777,7 +4879,8 @@ mod tests {
             &releases,
             Target::RadarrMovie { movie_id: 1 },
             &req,
-            ServarrLanguageCandidatePolicy::CustomFormatOrTitle
+            ServarrLanguageCandidatePolicy::CustomFormatOrTitle,
+            false,
         )
         .is_some());
     }
@@ -4800,9 +4903,48 @@ mod tests {
             Target::RadarrMovie { movie_id: 1 },
             &req,
             ServarrLanguageCandidatePolicy::Strict,
+            false,
         )
         .unwrap();
         assert_eq!(release_title(selected).as_deref(), Some("good"));
+    }
+
+    #[test]
+    fn prefer_non_torrent_selects_lower_scored_non_torrent_candidate() {
+        let req = LanguageRequirements {
+            enabled: true,
+            audio: vec!["eng".to_string()],
+            subtitles: Vec::new(),
+        };
+        let releases = vec![
+            json!({
+                "title":"torrent high score",
+                "protocol":"torrent",
+                "rejected": false,
+                "languages":[{"name":"English"}],
+                "customFormatScore": 1000
+            }),
+            json!({
+                "title":"usenet lower score",
+                "protocol":"usenet",
+                "rejected": false,
+                "languages":[{"name":"English"}],
+                "customFormatScore": 10
+            }),
+        ];
+
+        let selected = select_verified_release_for_target(
+            &releases,
+            Target::SonarrEpisode { episode_id: 77 },
+            &req,
+            ServarrLanguageCandidatePolicy::Strict,
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            release_title(selected).as_deref(),
+            Some("usenet lower score")
+        );
     }
 
     #[test]
@@ -4817,7 +4959,8 @@ mod tests {
             &releases,
             Target::RadarrMovie { movie_id: 1 },
             &req,
-            ServarrLanguageCandidatePolicy::Strict
+            ServarrLanguageCandidatePolicy::Strict,
+            false,
         )
         .is_none());
     }
@@ -4838,7 +4981,8 @@ mod tests {
             &releases,
             Target::RadarrMovie { movie_id: 1 },
             &req,
-            ServarrLanguageCandidatePolicy::Strict
+            ServarrLanguageCandidatePolicy::Strict,
+            false,
         )
         .is_some());
     }

--- a/src/servarr/api.rs
+++ b/src/servarr/api.rs
@@ -136,6 +136,7 @@ pub fn run_sonarr_language_audit(
 ) -> Result<AuditSummary> {
     let client = ApiClient::from_settings(IntegrationKind::Sonarr, settings)?;
     let queue_records = client.sonarr_queue_records()?;
+    client.sonarr_remove_bad_queue_items(&queue_records, redownload_options)?;
     let active_queue_episode_ids = sonarr_active_queue_episode_ids(&queue_records);
     let mut summary = client.sonarr_force_import_pending_language_upgrades(
         &queue_records,
@@ -1478,11 +1479,52 @@ impl ApiClient {
     }
 
     fn sonarr_delete_queue_item(&self, queue_id: i64) -> Result<()> {
+        self.sonarr_delete_queue_item_with_options(queue_id, false, false)
+    }
+
+    fn sonarr_delete_queue_item_with_options(
+        &self,
+        queue_id: i64,
+        remove_from_client: bool,
+        blocklist: bool,
+    ) -> Result<()> {
         let endpoint = format!(
-            "{}/api/v3/queue/{}?removeFromClient=false&blocklist=false",
-            self.base_url, queue_id
+            "{}/api/v3/queue/{}?removeFromClient={}&blocklist={}",
+            self.base_url, queue_id, remove_from_client, blocklist
         );
         self.delete(&endpoint)?;
+        Ok(())
+    }
+
+    fn sonarr_remove_bad_queue_items(
+        &self,
+        records: &[Value],
+        options: RedownloadOptions,
+    ) -> Result<()> {
+        for queue_item in records {
+            let Some(reason) = sonarr_bad_queue_reason(queue_item) else {
+                continue;
+            };
+            let Some(queue_id) = queue_item.get("id").and_then(Value::as_i64) else {
+                continue;
+            };
+            let title = queue_item
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("<queue item>");
+            if options.dry_run {
+                info!(
+                    "Sonarr language audit dry-run: would remove and blocklist bad queue item {} ('{}'): {}.",
+                    queue_id, title, reason
+                );
+                continue;
+            }
+            self.sonarr_delete_queue_item_with_options(queue_id, true, true)?;
+            info!(
+                "Sonarr language audit removed and blocklisted bad queue item {} ('{}'): {}.",
+                queue_id, title, reason
+            );
+        }
         Ok(())
     }
 
@@ -1829,6 +1871,56 @@ fn sonarr_active_queue_episode_ids(records: &[Value]) -> BTreeSet<i64> {
         .iter()
         .flat_map(sonarr_queue_item_episode_ids)
         .collect()
+}
+
+fn sonarr_bad_queue_reason(queue_item: &Value) -> Option<&'static str> {
+    let status = queue_item
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let tracked_status = queue_item
+        .get("trackedDownloadStatus")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if status != "completed" || tracked_status != "warning" {
+        return None;
+    }
+    let haystack = queue_status_message_text(queue_item);
+    if haystack.contains("invalid season or episode") {
+        return Some("invalid season or episode");
+    }
+    if haystack.contains("one or more episodes expected")
+        || haystack.contains("was not found in the grabbed release")
+        || haystack.contains("episode wasn't requested")
+        || haystack.contains("wrong episode")
+        || haystack.contains("wrong season")
+        || haystack.contains("full season pack")
+    {
+        return Some("episode mismatch or multi-episode pack");
+    }
+    None
+}
+
+fn queue_status_message_text(queue_item: &Value) -> String {
+    let mut parts = Vec::new();
+    if let Some(message) = queue_item.get("errorMessage").and_then(Value::as_str) {
+        parts.push(message.to_ascii_lowercase());
+    }
+    if let Some(messages) = queue_item.get("statusMessages").and_then(Value::as_array) {
+        for item in messages {
+            if let Some(title) = item.get("title").and_then(Value::as_str) {
+                parts.push(title.to_ascii_lowercase());
+            }
+            if let Some(nested) = item.get("messages").and_then(Value::as_array) {
+                for message in nested {
+                    if let Some(message) = message.as_str() {
+                        parts.push(message.to_ascii_lowercase());
+                    }
+                }
+            }
+        }
+    }
+    parts.join("\n")
 }
 
 fn radarr_queue_item_movie_id(queue_item: &Value) -> Option<i64> {
@@ -2621,6 +2713,45 @@ mod tests {
             },
         )
         .unwrap()
+    }
+
+    #[test]
+    fn sonarr_bad_queue_reason_detects_invalid_episode_and_mismatch() {
+        let invalid = json!({
+            "status": "completed",
+            "trackedDownloadStatus": "warning",
+            "statusMessages": [{
+                "title": "bad file.mp4",
+                "messages": ["Invalid season or episode"]
+            }]
+        });
+        assert_eq!(
+            sonarr_bad_queue_reason(&invalid),
+            Some("invalid season or episode")
+        );
+
+        let mismatch = json!({
+            "status": "completed",
+            "trackedDownloadStatus": "warning",
+            "statusMessages": [{
+                "title": "One or more episodes expected in this release were not imported or missing from the release",
+                "messages": ["Episode 2x05 was not found in the grabbed release"]
+            }]
+        });
+        assert_eq!(
+            sonarr_bad_queue_reason(&mismatch),
+            Some("episode mismatch or multi-episode pack")
+        );
+
+        let quality = json!({
+            "status": "completed",
+            "trackedDownloadStatus": "warning",
+            "statusMessages": [{
+                "title": "candidate.mkv",
+                "messages": ["Not an upgrade for existing episode file(s). Existing quality: Bluray-1080p. New Quality Bluray-720p."]
+            }]
+        });
+        assert_eq!(sonarr_bad_queue_reason(&quality), None);
     }
 
     #[test]

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -246,6 +246,7 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
             no_candidate_cooldown_days: args.servarr_language_audit_no_candidate_cooldown_days,
             latest_missing_no_candidate_cooldown_days: args
                 .servarr_language_audit_latest_missing_no_candidate_cooldown_days,
+            stale_queue_days: args.servarr_language_audit_stale_queue_days,
             episode_ids: parse_optional_i64_list(
                 args.servarr_language_audit_episode_ids.as_deref(),
             )?,

--- a/src/transcoder/app_entry.rs
+++ b/src/transcoder/app_entry.rs
@@ -247,6 +247,7 @@ fn run_servarr_language_audit(args: &Args) -> Result<()> {
             latest_missing_no_candidate_cooldown_days: args
                 .servarr_language_audit_latest_missing_no_candidate_cooldown_days,
             stale_queue_days: args.servarr_language_audit_stale_queue_days,
+            stale_queue_max_removals: args.servarr_language_audit_stale_queue_max_removals,
             episode_ids: parse_optional_i64_list(
                 args.servarr_language_audit_episode_ids.as_deref(),
             )?,


### PR DESCRIPTION
## Summary
- have Sonarr language audits remove+blocklist completed warning queue items with invalid season/episode parses
- also remove+blocklist completed warning queue items that clearly map to the wrong episode/season or multi-episode pack instead of a requested episode
- keep quality-only downgrade warnings in place so DPN can still force-import them when manual-import language evidence is valid
- add `--servarr-language-audit-stale-queue-days` / `servarr_language_audit_stale_queue_days` to remove+blocklist zero-size torrent queue items that never acquire metadata after a configurable number of days
- after removing a stale zero-size torrent, immediately search/grab another verified replacement candidate for the same episode instead of waiting for a later audit
- prefer non-torrent replacements after stale torrent cleanup, and add `--servarr-language-audit-stale-queue-max-removals` / `servarr_language_audit_stale_queue_max_removals` to cap cleanup/requeue churn per audit

## Testing
- `cargo fmt --check`
- `git diff --check`
- CI checks exercise the FFmpeg 8/vcpkg build path