### PR TITLE
Sanitize text subtitle font styling

### DIFF
--- a/src/transcoder/app_convert.rs
+++ b/src/transcoder/app_convert.rs
@@ -659,8 +659,14 @@ pub(crate) fn convert_video_file(
                 return Err(err);
             }
         }
+        if media_type == ffi::AVMEDIA_TYPE_SUBTITLE {
+            sanitize_mov_text_encode_context_header(&mut encode_context);
+        }
 
         output_stream.set_codecpar(encode_context.extract_codecpar());
+        if media_type == ffi::AVMEDIA_TYPE_SUBTITLE {
+            sanitize_mov_text_stream_header(&mut output_stream);
+        }
 
         let stream_process_context = StreamProcessingContext {
             decode_context,

--- a/src/transcoder/pipeline_codec.rs
+++ b/src/transcoder/pipeline_codec.rs
@@ -365,7 +365,7 @@ pub(crate) fn set_subtitle_codec_par(
     encode_context: &mut AVCodecContext,
     _output_stream: &mut AVStreamMut,
 ) {
-    // Set subtitle encoder parameters based on the input subtitle stream
+    // Set subtitle encoder parameters based on the input subtitle stream.
     encode_context.set_time_base(decode_context.time_base);
 
     if decode_context.subtitle_header_size > 0 {
@@ -376,6 +376,7 @@ pub(crate) fn set_subtitle_codec_par(
                 decode_context.subtitle_header_size as usize,
             )
         });
+        sanitize_mov_text_subtitle_header(&mut new_subtitle_header);
 
         // SAFETY: FFmpeg expects subtitle_header to be allocated with av_malloc* and owned by
         // the codec context. We allocate exactly new_subtitle_header.len() bytes and copy from a
@@ -393,4 +394,64 @@ pub(crate) fn set_subtitle_codec_par(
     }
 
     // Codec parameters are extracted after the encoder is opened.
+}
+
+pub(crate) fn sanitize_mov_text_encode_context_header(encode_context: &mut AVCodecContext) {
+    if encode_context.subtitle_header_size <= 0 || encode_context.subtitle_header.is_null() {
+        return;
+    }
+    let header = unsafe {
+        std::slice::from_raw_parts_mut(
+            encode_context.subtitle_header,
+            encode_context.subtitle_header_size as usize,
+        )
+    };
+    sanitize_mov_text_subtitle_header(header);
+}
+
+pub(crate) fn sanitize_mov_text_stream_header(output_stream: &mut AVStreamMut) {
+    let codecpar = output_stream.codecpar_mut();
+    if codecpar.extradata_size <= 0 || codecpar.extradata.is_null() {
+        return;
+    }
+    let header = unsafe {
+        std::slice::from_raw_parts_mut(codecpar.extradata, codecpar.extradata_size as usize)
+    };
+    sanitize_mov_text_subtitle_header(header);
+}
+
+fn sanitize_mov_text_subtitle_header(header: &mut [u8]) {
+    // MOV_TEXT/tx3g stores the default style font size in the default style
+    // record. FFmpeg needs this header to open the MOV_TEXT encoder, but copying
+    // source values like 66 makes Plex stack that embedded size with the user's
+    // subtitle-size setting. Keep the required header and clamp the default font
+    // size to a neutral tx3g value.
+    const TX3G_DEFAULT_STYLE_FONT_SIZE_OFFSET: usize = 25;
+    const NEUTRAL_TX3G_FONT_SIZE: u8 = 12;
+    if let Some(font_size) = header.get_mut(TX3G_DEFAULT_STYLE_FONT_SIZE_OFFSET) {
+        if *font_size > 24 {
+            *font_size = NEUTRAL_TX3G_FONT_SIZE;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mov_text_header_sanitizer_clamps_large_default_font_size() {
+        let mut header = vec![0u8; 32];
+        header[25] = 66;
+        sanitize_mov_text_subtitle_header(&mut header);
+        assert_eq!(header[25], 12);
+    }
+
+    #[test]
+    fn mov_text_header_sanitizer_leaves_normal_default_font_size() {
+        let mut header = vec![0u8; 32];
+        header[25] = 18;
+        sanitize_mov_text_subtitle_header(&mut header);
+        assert_eq!(header[25], 18);
+    }
 }

--- a/src/transcoder/pipeline_streams.rs
+++ b/src/transcoder/pipeline_streams.rs
@@ -9,6 +9,7 @@ use rsmpeg::avutil::{AVAudioFifo, AVFrame, AVSamples};
 use rsmpeg::error::RsmpegError;
 use rsmpeg::ffi;
 use rsmpeg::swscale::SwsContext;
+use std::ffi::CStr;
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use crate::ffmpeg_utils::{
@@ -481,7 +482,8 @@ pub(crate) fn process_subtitle_stream(
         .decode_subtitle(Some(packet))
     {
         Ok(sub) => {
-            if let Some(subtitle) = sub {
+            if let Some(mut subtitle) = sub {
+                sanitize_text_subtitle_styles(&mut subtitle);
                 debug!(
                     "Subtitle stream {} raw packet pts={} dts={} duration={}",
                     stream_processing_context.input_stream_index,
@@ -489,7 +491,7 @@ pub(crate) fn process_subtitle_stream(
                     packet.dts,
                     packet.duration
                 );
-                let Some(encoded_subtitle) = (match encode_subtitle_to_vec(
+                let Some(mut encoded_subtitle) = (match encode_subtitle_to_vec(
                     &mut stream_processing_context.encode_context,
                     &subtitle,
                     stream_processing_context.input_stream_index.as_i32(),
@@ -504,6 +506,7 @@ pub(crate) fn process_subtitle_stream(
                 }) else {
                     return Ok(());
                 };
+                sanitize_mov_text_packet_text_and_strip_style_boxes(&mut encoded_subtitle);
 
                 // Create a new packet for the encoded subtitle
                 let mut encoded_packet = AVPacket::new();
@@ -632,6 +635,153 @@ fn handle_subtitle_stream_failure(
 /// directly so subtitle packets can preserve legitimate trailing zero bytes and
 /// oversized text events can retry with a larger buffer before the stream is
 /// skipped by policy.
+fn sanitize_text_subtitle_styles(subtitle: &mut rsmpeg::avcodec::AVSubtitle) -> bool {
+    if subtitle.num_rects == 0 || subtitle.rects.is_null() {
+        return false;
+    }
+
+    let mut changed = false;
+    for i in 0..subtitle.num_rects {
+        let rect_ptr = unsafe { *subtitle.rects.add(i as usize) };
+        if rect_ptr.is_null() {
+            continue;
+        }
+        let rect = unsafe { &mut *rect_ptr };
+        if rect.type_ == ffi::SUBTITLE_TEXT && !rect.text.is_null() {
+            changed |= sanitize_c_string_in_place(rect.text);
+        }
+        if rect.type_ == ffi::SUBTITLE_ASS && !rect.ass.is_null() {
+            changed |= sanitize_c_string_in_place(rect.ass);
+        }
+    }
+    changed
+}
+
+fn sanitize_c_string_in_place(ptr: *mut std::os::raw::c_char) -> bool {
+    let original = unsafe { CStr::from_ptr(ptr) };
+    let original_bytes = original.to_bytes();
+    let original_text = String::from_utf8_lossy(original_bytes);
+    let sanitized = sanitize_subtitle_style_text(&original_text);
+    if sanitized.as_bytes() == original_bytes || sanitized.len() > original_bytes.len() {
+        return false;
+    }
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(sanitized.as_ptr(), ptr.cast::<u8>(), sanitized.len());
+        *ptr.add(sanitized.len()) = 0;
+    }
+    true
+}
+
+fn sanitize_subtitle_style_text(input: &str) -> String {
+    strip_empty_ass_override_blocks(&strip_ass_font_overrides(&strip_html_font_tags(input)))
+}
+
+fn strip_html_font_tags(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find('<') {
+        out.push_str(&rest[..start]);
+        let after_start = &rest[start..];
+        let Some(end) = after_start.find('>') else {
+            out.push_str(after_start);
+            return out;
+        };
+        let tag = &after_start[1..end].trim_start();
+        let tag_lower = tag.to_ascii_lowercase();
+        let is_font_tag = tag_lower == "font"
+            || tag_lower == "/font"
+            || tag_lower.starts_with("font ")
+            || tag_lower.starts_with("font\t")
+            || tag_lower.starts_with("/font ")
+            || tag_lower.starts_with("/font\t");
+        if !is_font_tag {
+            out.push_str(&after_start[..=end]);
+        }
+        rest = &after_start[end + 1..];
+    }
+    out.push_str(rest);
+    out
+}
+
+fn strip_empty_ass_override_blocks(input: &str) -> String {
+    input.replace("{}", "")
+}
+
+fn strip_ass_font_overrides(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            let mut lookahead = chars.clone();
+            let tag = match (lookahead.next(), lookahead.next(), lookahead.next()) {
+                (Some('f') | Some('F'), Some('s') | Some('S'), Some('c') | Some('C')) => {
+                    match lookahead.next() {
+                        Some('x') | Some('X') => Some(("fsc", 4)),
+                        Some('y') | Some('Y') => Some(("fsc", 4)),
+                        _ => None,
+                    }
+                }
+                (
+                    Some('f') | Some('F'),
+                    Some('s') | Some('S'),
+                    Some('0'..='9' | '.' | '+' | '-'),
+                ) => Some(("fs", 2)),
+                (Some('f') | Some('F'), Some('n') | Some('N'), _) => Some(("fn", 2)),
+                _ => None,
+            };
+            if let Some((tag, tag_len)) = tag {
+                for _ in 0..tag_len {
+                    chars.next();
+                }
+                if tag == "fs" || tag == "fsc" {
+                    while matches!(chars.peek(), Some('0'..='9' | '.' | '+' | '-')) {
+                        chars.next();
+                    }
+                    continue;
+                }
+                while let Some(next) = chars.peek().copied() {
+                    if next == '\\' || next == '}' || next == '{' {
+                        break;
+                    }
+                    chars.next();
+                }
+                continue;
+            }
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn sanitize_mov_text_packet_text_and_strip_style_boxes(packet: &mut Vec<u8>) -> bool {
+    if packet.len() < 2 {
+        return false;
+    }
+    let text_len = u16::from_be_bytes([packet[0], packet[1]]) as usize;
+    let text_end = 2usize.saturating_add(text_len);
+    if text_end > packet.len() {
+        return false;
+    }
+
+    let original_text = String::from_utf8_lossy(&packet[2..text_end]);
+    let sanitized_text = sanitize_subtitle_style_text(&original_text);
+    if sanitized_text.len() > u16::MAX as usize {
+        return false;
+    }
+
+    let had_style_boxes = text_end < packet.len();
+    let text_changed = sanitized_text.as_bytes() != &packet[2..text_end];
+    if !had_style_boxes && !text_changed {
+        return false;
+    }
+
+    packet.clear();
+    packet.extend_from_slice(&(sanitized_text.len() as u16).to_be_bytes());
+    packet.extend_from_slice(sanitized_text.as_bytes());
+    true
+}
+
 fn encode_subtitle_to_vec(
     encode_context: &mut AVCodecContext,
     subtitle: &rsmpeg::avcodec::AVSubtitle,
@@ -733,6 +883,47 @@ pub(crate) fn load_encode_and_write(
 #[cfg(test)]
 mod resize_quality_tests {
     use super::*;
+
+    #[test]
+    fn subtitle_style_sanitizer_removes_html_font_tags() {
+        let input =
+            "<font face=\"Octarine\" size=\"66\"><b><font size=\"76\">What?!</font></b></font>";
+        assert_eq!(sanitize_subtitle_style_text(input), "<b>What?!</b>");
+    }
+
+    #[test]
+    fn subtitle_style_sanitizer_removes_ass_font_overrides() {
+        let input = "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,{\\an8\\fs76\\fnOctarine\\fscx150\\fscy120}Hello";
+        assert_eq!(
+            sanitize_subtitle_style_text(input),
+            "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,{\\an8}Hello"
+        );
+    }
+
+    #[test]
+    fn subtitle_style_sanitizer_preserves_non_font_tags() {
+        let input = "{\\fsp2\\bord3}<i>Hello</i>";
+        assert_eq!(sanitize_subtitle_style_text(input), input);
+    }
+
+    #[test]
+    fn subtitle_style_sanitizer_removes_empty_ass_blocks() {
+        assert_eq!(sanitize_subtitle_style_text("{}{}What?!"), "What?!");
+    }
+
+    #[test]
+    fn mov_text_packet_sanitizer_strips_text_style_and_trailing_boxes() {
+        let text = b"<font size=\"66\">Hello</font>";
+        let mut packet = Vec::new();
+        packet.extend_from_slice(&(text.len() as u16).to_be_bytes());
+        packet.extend_from_slice(text);
+        packet.extend_from_slice(b"styl");
+
+        assert!(sanitize_mov_text_packet_text_and_strip_style_boxes(
+            &mut packet
+        ));
+        assert_eq!(packet, vec![0, 5, b'H', b'e', b'l', b'l', b'o']);
+    }
 
     #[test]
     fn same_size_transform_keeps_legacy_fast_scaler_path() {


### PR DESCRIPTION
## Summary
- sanitize text subtitle cues before MOV_TEXT muxing by removing font-size/font-face overrides and empty ASS override blocks
- clamp tx3g default subtitle font size to a neutral value so Plex client subtitle size remains in control
- strip MOV_TEXT per-sample style boxes after encoding while preserving cue text and timings

## Validation
- cargo test subtitle_style_sanitizer
- cargo test mov_text_packet_sanitizer
- cargo test mov_text_header_sanitizer
- cargo build --release
- Plex host conversion smoke test on Sample Series S01E02 with extracted SRT showing font size reduced from 66 to 12