### PR TITLE
Fix non-monotonic encoded packet DTS

### DIFF
--- a/src/ffmpeg_utils.rs
+++ b/src/ffmpeg_utils.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Context, Result};
 use clap::{value_parser, Parser};
+use log::debug;
 use rsmpeg::avcodec::AVCodecContext;
 use rsmpeg::avformat::AVFormatContextOutput;
 use rsmpeg::avutil::{AVAudioFifo, AVFrame, AVSamples};
@@ -14,6 +15,7 @@ use std::sync::atomic::AtomicI64;
 
 use crate::devices::{self, DeviceFamily};
 use crate::gpu::HwAccel;
+use crate::transcoder::timestamp::enforce_monotonic_dts;
 use crate::transcoder::{AudioQuality, VideoCodecPreference, VideoQuality};
 use crate::types::{
     OcrEngine, OcrFormat, OutputFormat, PrimaryVideoCriteria, ResizeBackend, ResizeQuality,
@@ -770,6 +772,7 @@ pub(crate) fn encode_and_write_frame(
     output_format_context: &mut AVFormatContextOutput,
     stream_index: usize,
     frame: Option<AVFrame>,
+    last_written_dts: &mut Option<i64>,
 ) -> Result<()> {
     encode_context
         .send_frame(frame.as_ref())
@@ -797,6 +800,17 @@ pub(crate) fn encode_and_write_frame(
                 .context("Failed to get stream")?
                 .time_base,
         );
+
+        if let Some((packet_dts, adjusted)) = enforce_monotonic_dts(&mut packet, *last_written_dts)
+        {
+            debug!(
+                "Encoded stream {} adjusted DTS from {} to {}",
+                stream_index, packet_dts, adjusted
+            );
+        }
+        if packet.dts != ffi::AV_NOPTS_VALUE {
+            *last_written_dts = Some(packet.dts);
+        }
 
         output_format_context
             .write_frame(&mut packet)

--- a/src/transcoder/app_convert.rs
+++ b/src/transcoder/app_convert.rs
@@ -917,6 +917,7 @@ fn flush_stream_contexts(
                     output_format_context,
                     context.output_stream_index.as_usize(),
                     None,
+                    &mut context.last_written_dts,
                 )
                 .context("Failed to flush video encoder.")?;
                 if let Some(dev) = context.hw_device_ctx {
@@ -932,6 +933,7 @@ fn flush_stream_contexts(
                             &mut context.encode_context,
                             context.output_stream_index.as_i32(),
                             &mut context.pts,
+                            &mut context.last_written_dts,
                         )
                         .context("Failed to drain buffered audio samples.")?;
                     }
@@ -941,6 +943,7 @@ fn flush_stream_contexts(
                     output_format_context,
                     context.output_stream_index.as_usize(),
                     None,
+                    &mut context.last_written_dts,
                 )
                 .context("Failed to flush audio encoder.")?;
             }

--- a/src/transcoder/pipeline_streams.rs
+++ b/src/transcoder/pipeline_streams.rs
@@ -211,6 +211,7 @@ pub(crate) fn process_video_stream(
             output_format_context,
             stream_processing_context.output_stream_index.as_usize(),
             Some(new_frame),
+            &mut stream_processing_context.last_written_dts,
         )?;
     }
 
@@ -451,6 +452,7 @@ pub(crate) fn process_audio_stream(
                 &mut stream_processing_context.encode_context,
                 stream_processing_context.output_stream_index.as_i32(),
                 &mut stream_processing_context.pts,
+                &mut stream_processing_context.last_written_dts,
             )?;
         }
     }
@@ -845,6 +847,7 @@ pub(crate) fn load_encode_and_write(
     encode_context: &mut AVCodecContext,
     stream_index: i32,
     pts: &mut AtomicI64,
+    last_written_dts: &mut Option<i64>,
 ) -> Result<()> {
     let frame_size = preferred_audio_frame_size(encode_context, fifo.size()).min(fifo.size());
     if frame_size <= 0 {
@@ -875,6 +878,7 @@ pub(crate) fn load_encode_and_write(
         output_format_context,
         stream_index as usize,
         Some(frame),
+        last_written_dts,
     )
     .context("Error encoding audio frame!")?;
 

--- a/src/transcoder/timestamp.rs
+++ b/src/transcoder/timestamp.rs
@@ -76,3 +76,42 @@ pub(crate) fn enforce_monotonic_dts(
     }
     Some((current, adjusted))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsmpeg::avcodec::AVPacket;
+
+    #[test]
+    fn enforce_monotonic_dts_allows_increasing_packets() {
+        let mut packet = AVPacket::new();
+        packet.set_dts(11);
+        packet.set_pts(12);
+
+        assert_eq!(enforce_monotonic_dts(&mut packet, Some(10)), None);
+        assert_eq!(packet.dts, 11);
+        assert_eq!(packet.pts, 12);
+    }
+
+    #[test]
+    fn enforce_monotonic_dts_clamps_duplicate_dts_and_pts() {
+        let mut packet = AVPacket::new();
+        packet.set_dts(10);
+        packet.set_pts(10);
+
+        assert_eq!(enforce_monotonic_dts(&mut packet, Some(10)), Some((10, 11)));
+        assert_eq!(packet.dts, 11);
+        assert_eq!(packet.pts, 11);
+    }
+
+    #[test]
+    fn enforce_monotonic_dts_preserves_later_pts() {
+        let mut packet = AVPacket::new();
+        packet.set_dts(10);
+        packet.set_pts(15);
+
+        assert_eq!(enforce_monotonic_dts(&mut packet, Some(10)), Some((10, 11)));
+        assert_eq!(packet.dts, 11);
+        assert_eq!(packet.pts, 15);
+    }
+}


### PR DESCRIPTION
## Summary

- track last written DTS for encoded video/audio packets
- apply the existing monotonic DTS clamp before MP4 muxing encoded packets
- add unit coverage for duplicate DTS adjustment

Fixes #170.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -q enforce_monotonic_dts -- --nocapture`
- `cargo build --release`
- Real Cagliostro repro now succeeds:
  - input: `The Castle of Cagliostro (1979) Bluray-1080p.mkv`
  - output: `/tmp/cagliostro-dpn-fix-test.mp4`
  - DPN completed and output validation passed
