### PR TITLE
chore(release): v1.1.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0-beta.7] - 2026-07-18
+
+### OCR Reliability
+
+- Made PP-OCR/Tesseract fallback conservative for PP-OCR-routed languages so
+  high-confidence PP-OCR output is no longer replaced by worse Tesseract text.
+- Added outlined VobSub OCR fixtures covering glued and fragmented bitmap
+  subtitle artifacts.
+- Fixed non-monotonic encoded packet DTS handling before MP4 muxing for audio
+  and video packets.
+
+### Servarr Imports
+
+- Fixed Radarr pending-language manual imports by hydrating movie IDs, using the
+  command API path, and keeping fallback import paths parse-friendly.
+
 ## [1.1.0-beta.6] - 2026-07-09
 
 ### Servarr Language Upgrades

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0-only"
 documentation = "https://github.com/ns-mkusper/direct-play-nice"
 homepage = "https://github.com/ns-mkusper/direct-play-nice"
 repository = "https://github.com/ns-mkusper/direct-play-nice"
-version = "1.1.0-beta.6"
+version = "1.1.0-beta.7"
 edition = "2021"
 
 


### PR DESCRIPTION
## Summary
- Bump crate version to `1.1.0-beta.7`.
- Add concrete changelog notes for the OCR fallback, DTS, and Radarr import fixes.

## Validation
- `bash scripts/validate_release_changelog.sh`
- `git diff --check`

Release PR for v1.1.0-beta.7.